### PR TITLE
Fix greeting payload type

### DIFF
--- a/Bot.Shared/DTOs/Events.cs
+++ b/Bot.Shared/DTOs/Events.cs
@@ -34,7 +34,7 @@ public record UserIntentDetected(
     MemoPayload? MemoPayload = null,
     FeedbackPayload? FeedbackPayload = null,
     SignupPayload? SignupPayload = null,
-    GrettingPayload? GreetingPayload = null,
+    GreetingPayload? GreetingPayload = null,
     UnknownPayload UnknownPayload = null,
     string? PhoneNumber = null);
 

--- a/Bot.Shared/Payloads.cs
+++ b/Bot.Shared/Payloads.cs
@@ -31,7 +31,7 @@ public record FeedbackPayload(int Rating, string Comment);
 
 public record SignupPayload(string FullName, string Phone, string NIN, string BVN);
 
-public record GrettingPayload(string message);
+public record GreetingPayload(string Message);
 public record UnknownPayload(string Message);
 
 // UX


### PR DESCRIPTION
## Summary
- fix typo in the greeting payload record and in related DTO

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*