### PR TITLE
Fix template return message

### DIFF
--- a/Bot.Core/Services/TemplateRenderingService.cs
+++ b/Bot.Core/Services/TemplateRenderingService.cs
@@ -36,7 +36,7 @@ public class TemplateRenderingService(IOptions<TemplateSettings> opts, ILogger<T
         catch (Exception ex)
         {
             log.LogError(ex, "Failed to render template {Template}", templateName);
-            return "⚠️ Rendering error.";
+            return "⚠ Template error";
         }
     }
 


### PR DESCRIPTION
## Summary
- fix typo causing truncated error string in TemplateRenderingService

## Testing
- `dotnet test` *(fails: command not found)*