### PR TITLE
Convert intent strings to enum

### DIFF
--- a/Bot.Core/StateMachine/Consumers/UX/ResolveQuickReplyCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/UX/ResolveQuickReplyCmdConsumer.cs
@@ -44,7 +44,7 @@ public class ResolveQuickReplyCmdConsumer(
 
         await bus.Publish(new UserIntentDetected(
             userId,
-            "transfer",
+            Bot.Shared.Enums.IntentType.Transfer,
             payload));
     }
 }

--- a/Bot.Infrastructure/SagaMigrations/20250516132900_Initial.Designer.cs
+++ b/Bot.Infrastructure/SagaMigrations/20250516132900_Initial.Designer.cs
@@ -62,8 +62,8 @@ namespace Bot.Infrastructure.SagaMigrations
                     b.Property<string>("PendingIntentPayload")
                         .HasColumnType("text");
 
-                    b.Property<string>("PendingIntentType")
-                        .HasColumnType("text");
+                    b.Property<int?>("PendingIntentType")
+                        .HasColumnType("integer");
 
                     b.Property<string>("PhoneNumber")
                         .HasColumnType("text");

--- a/Bot.Infrastructure/SagaMigrations/20250516132900_Initial.cs
+++ b/Bot.Infrastructure/SagaMigrations/20250516132900_Initial.cs
@@ -34,7 +34,7 @@ namespace Bot.Infrastructure.SagaMigrations
                     TempBVN = table.Column<string>(type: "text", nullable: true),
                     SessionId = table.Column<Guid>(type: "uuid", nullable: false),
                     PhoneNumber = table.Column<string>(type: "text", nullable: true),
-                    PendingIntentType = table.Column<string>(type: "text", nullable: true),
+                    PendingIntentType = table.Column<int>(type: "integer", nullable: true),
                     PendingIntentPayload = table.Column<string>(type: "text", nullable: true),
                     RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true)
                 },

--- a/Bot.Infrastructure/SagaMigrations/BotStateDbContextModelSnapshot.cs
+++ b/Bot.Infrastructure/SagaMigrations/BotStateDbContextModelSnapshot.cs
@@ -59,8 +59,8 @@ namespace Bot.Infrastructure.SagaMigrations
                     b.Property<string>("PendingIntentPayload")
                         .HasColumnType("text");
 
-                    b.Property<string>("PendingIntentType")
-                        .HasColumnType("text");
+                    b.Property<int?>("PendingIntentType")
+                        .HasColumnType("integer");
 
                     b.Property<string>("PhoneNumber")
                         .HasColumnType("text");

--- a/Bot.Shared/DTOs/Events.cs
+++ b/Bot.Shared/DTOs/Events.cs
@@ -26,7 +26,7 @@ public record PinInvalid(Guid CorrelationId, string Reason);
 /* intent */
 public record UserIntentDetected(
     Guid CorrelationId,
-    string Intent,
+    Bot.Shared.Enums.IntentType Intent,
     TransferPayload? TransferPayload = null,
     BillPayload? BillPayload = null,
     GoalPayload? GoalPayload = null,

--- a/Bot.Shared/Enums/IntentType.cs
+++ b/Bot.Shared/Enums/IntentType.cs
@@ -1,0 +1,14 @@
+namespace Bot.Shared.Enums;
+
+public enum IntentType
+{
+    Unknown = 0,
+    Greeting,
+    Signup,
+    Transfer,
+    BillPay,
+    SetGoal,
+    ScheduleRecurring,
+    Memo,
+    Feedback
+}

--- a/Bot.Shared/Models/IntentValidator.cs
+++ b/Bot.Shared/Models/IntentValidator.cs
@@ -9,15 +9,15 @@ public static class IntentValidator
     {
         return intent.Intent switch
         {
-            "transfer" => ValidateTransfer(intent.TransferPayload!),
-            "memo" => ValidateMemo(intent.MemoPayload!),
-            "billpay" => ValidateBill(intent.BillPayload!),
-            "signup" => ValidateSignup(intent.SignupPayload!),
-            "set_goal" => ValidateGoal(intent.GoalPayload!),
-            "schedule_recurring" => ValidateRecurring(intent.RecurringPayload!),
-            "feedback" => ValidateFeedback(intent.FeedbackPayload!),
-            "greeting" => ValidateGreeting(),
-            "unknown" => ValidateUnknown(),
+            Enums.IntentType.Transfer => ValidateTransfer(intent.TransferPayload!),
+            Enums.IntentType.Memo => ValidateMemo(intent.MemoPayload!),
+            Enums.IntentType.BillPay => ValidateBill(intent.BillPayload!),
+            Enums.IntentType.Signup => ValidateSignup(intent.SignupPayload!),
+            Enums.IntentType.SetGoal => ValidateGoal(intent.GoalPayload!),
+            Enums.IntentType.ScheduleRecurring => ValidateRecurring(intent.RecurringPayload!),
+            Enums.IntentType.Feedback => ValidateFeedback(intent.FeedbackPayload!),
+            Enums.IntentType.Greeting => ValidateGreeting(),
+            Enums.IntentType.Unknown => ValidateUnknown(),
             _ => ValidationResult.Fail("❌ Unknown intent provided.")
         };
     }

--- a/Bot.Shared/Models/SagaStateMachineInstance.cs
+++ b/Bot.Shared/Models/SagaStateMachineInstance.cs
@@ -28,7 +28,7 @@ public class BotState : SagaStateMachineInstance
     public Guid SessionId { get; set; }
     public string? PhoneNumber { get; set; }
 
-    public string? PendingIntentType { get; set; } // "transfer", "billpay", etc.
+    public Bot.Shared.Enums.IntentType? PendingIntentType { get; set; } // Transfer, BillPay, etc.
     public string? PendingIntentPayload { get; set; } // JSON string of full UserIntentDetected
 
     public byte[]? RowVersion { get; set; }

--- a/Bot.Tests/Services/NlpServiceTests.cs
+++ b/Bot.Tests/Services/NlpServiceTests.cs
@@ -56,7 +56,7 @@ public class NlpServiceTests : IDisposable
         var service = CreateService(json);
         var result = await service.DetectIntentAsync(Guid.NewGuid(), "transfer rent", phoneNumber:"+2349043844315");
 
-        result.Intent.Should().Be("transfer");
+        result.Intent.Should().Be(Bot.Shared.Enums.IntentType.Transfer);
         result.TransferPayload!.ToAccount.Should().Be("1234567890");
         result.TransferPayload.BankCode.Should().Be("058");
         result.TransferPayload.Amount.Should().Be(1000);
@@ -78,7 +78,7 @@ public class NlpServiceTests : IDisposable
         var service = CreateService(json);
         var result = await service.DetectIntentAsync(Guid.NewGuid(), "pay DSTV", "+2349043844315");
 
-        result.Intent.Should().Be("billpay");
+        result.Intent.Should().Be(Bot.Shared.Enums.IntentType.BillPay);
         result.BillPayload!.BillerCode.Should().Be("DSTV");
         result.BillPayload.CustomerRef.Should().Be("00112233");
         result.BillPayload.Amount.Should().Be(5500);
@@ -100,7 +100,7 @@ public class NlpServiceTests : IDisposable
         var service = CreateService(json);
         var result = await service.DetectIntentAsync(Guid.NewGuid(), "sign me up", "+2349043844315");
 
-        result.Intent.Should().Be("signup");
+        result.Intent.Should().Be(Bot.Shared.Enums.IntentType.Signup);
         result.SignupPayload!.FullName.Should().Be("Jane Doe");
         result.SignupPayload.Phone.Should().Be("+2348123456789");
         result.SignupPayload.NIN.Should().Be("12345678901");
@@ -121,7 +121,7 @@ public class NlpServiceTests : IDisposable
         var service = CreateService(json);
         var result = await service.DetectIntentAsync(Guid.NewGuid(), "feedback", "+2349043844315");
 
-        result.Intent.Should().Be("feedback");
+        result.Intent.Should().Be(Bot.Shared.Enums.IntentType.Feedback);
         result.FeedbackPayload!.Rating.Should().Be(5);
         result.FeedbackPayload.Comment.Should().Be("Great job");
     }
@@ -141,7 +141,7 @@ public class NlpServiceTests : IDisposable
         var service = CreateService(json);
         var result = await service.DetectIntentAsync(Guid.NewGuid(), "add memo", "+2349043844315");
 
-        result.Intent.Should().Be("memo");
+        result.Intent.Should().Be(Bot.Shared.Enums.IntentType.Memo);
         result.MemoPayload!.TransactionId.Should().Be(txId);
         result.MemoPayload.MemoText.Should().Be("January rent");
     }
@@ -154,7 +154,7 @@ public class NlpServiceTests : IDisposable
         var service = CreateService(json);
         var result = await service.DetectIntentAsync(Guid.NewGuid(), "bla bla", "+2349043844315");
 
-        result.Intent.Should().Be("unknown");
+        result.Intent.Should().Be(Bot.Shared.Enums.IntentType.Unknown);
     }
 
     [Fact]

--- a/Bot.Tests/StateMachine/BotStateMachineOnboardingTests.cs
+++ b/Bot.Tests/StateMachine/BotStateMachineOnboardingTests.cs
@@ -48,7 +48,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     public async Task ONB_01_Should_Transition_To_AskFullName_On_Signup_Intent()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
 
         var instance = await _sagaHarness.Exists(id, x => x.AskFullName, TimeSpan.FromSeconds(5));
 
@@ -59,7 +59,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     public async Task ONB_02_Should_Transition_To_AskNin_On_FullNameProvided()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Jane Doe"));
 
         var instance = await _sagaHarness.Exists(id, x => x.AskNin, TimeSpan.FromSeconds(5));
@@ -72,7 +72,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     public async Task ONB_03_Should_Transition_To_AskBvn_On_NinVerified()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "John Smith"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -87,7 +87,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     public async Task ONB_04_Should_Return_To_AskNin_On_NinRejected()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
         await _harness.Bus.Publish(new NinProvided(id, "invalid"));
         await _harness.Bus.Publish(new NinRejected(id, "NIN is invalid"));
@@ -100,7 +100,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     public async Task ONB_05_Should_Transition_To_AwaitingKyc_On_BvnVerified()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -117,7 +117,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     public async Task ONB_06_Should_Finalize_On_SignupFailed()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -133,7 +133,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -153,7 +153,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -172,7 +172,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -190,7 +190,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Ayomide Fajobi"));
         await _harness.Bus.Publish(new NinProvided(id, "11223344556"));
         await _harness.Bus.Publish(new NinVerified(id, "11223344556"));
@@ -210,7 +210,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -227,8 +227,8 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
 
         var count = _sagaHarness.Sagas.Count();
         testOutputHelper.WriteLine(count.ToString());
@@ -239,7 +239,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
 
         // Wait for AskNin state to be set
@@ -261,7 +261,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
         var id = NewId.NextGuid();
 
         // Complete onboarding
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Ayomide"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
@@ -279,7 +279,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
 
         // Send a sensitive intent (transfer) now that we're in Ready
         var payload = new TransferPayload("1234567890", "001", 5000, "Test");
-        await _harness.Bus.Publish(new UserIntentDetected(id, "transfer", TransferPayload: payload));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer, TransferPayload: payload));
 
         // Saga should transition to AwaitingPinValidate
         var pinPrompt = await _sagaHarness.Exists(id, x => x.AwaitingPinValidate, TimeSpan.FromSeconds(5));
@@ -289,7 +289,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
         var saga = _sagaHarness.Sagas.Contains(id);
         Assert.NotNull(saga);
         saga!.PendingIntentPayload = "<<<INVALID_JSON>>>";
-        saga.PendingIntentType = "transfer";
+        saga.PendingIntentType = Bot.Shared.Enums.IntentType.Transfer;
 
         // Publish PIN validated event
         var ex = await Record.ExceptionAsync(() => _harness.Bus.Publish(new PinValidated(id)));
@@ -307,7 +307,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
 
         var askFullName = await _sagaHarness.Exists(id, x => x.AskFullName, TimeSpan.FromSeconds(5));
         Assert.True(askFullName.HasValue, "Saga should be created in AskFullName");
@@ -317,7 +317,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
         var askNin = await _sagaHarness.Exists(id, x => x.AskNin, TimeSpan.FromSeconds(5));
         Assert.True(askNin.HasValue, "Saga should be in AskNin");
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "alien_command"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Unknown));
 
         var saga = _sagaHarness.Sagas.Contains(id);
         Assert.NotNull(saga);

--- a/Bot.Tests/StateMachine/BotStateMachineRecurringTests.cs
+++ b/Bot.Tests/StateMachine/BotStateMachineRecurringTests.cs
@@ -52,11 +52,11 @@ public class BotStateMachineRecurringTests : IAsyncLifetime
         var recurringId = Guid.NewGuid();
         var payload = new TransferPayload("111111", "001", 12345, "Test");
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "transfer", TransferPayload: payload));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer, TransferPayload: payload));
 
         var saga = _sagaHarness.Sagas.Contains(id);
-        saga.PendingIntentType = "transfer";
-        saga.PendingIntentPayload = JsonSerializer.Serialize(new UserIntentDetected(id, "transfer", TransferPayload: payload));
+        saga.PendingIntentType = Bot.Shared.Enums.IntentType.Transfer;
+        saga.PendingIntentPayload = JsonSerializer.Serialize(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer, TransferPayload: payload));
 
         await _harness.Bus.Publish(new RecurringExecuted(id, recurringId));
 
@@ -69,7 +69,7 @@ public class BotStateMachineRecurringTests : IAsyncLifetime
     public async Task REC_02_Should_Stay_In_Current_State_On_RecurringFailed()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "transfer"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer));
 
         await _harness.Bus.Publish(new RecurringFailed(id, "failed"));
 
@@ -83,11 +83,11 @@ public class BotStateMachineRecurringTests : IAsyncLifetime
     {
         var id = NewId.NextGuid();
         var recurringId = Guid.NewGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "transfer"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer));
         var payload = new TransferPayload("111111", "001", 12345, "Test");
         var saga = _sagaHarness.Sagas.Contains(id);
-        saga.PendingIntentType = "transfer";
-        saga.PendingIntentPayload = JsonSerializer.Serialize(new UserIntentDetected(id, "transfer", payload));
+        saga.PendingIntentType = Bot.Shared.Enums.IntentType.Transfer;
+        saga.PendingIntentPayload = JsonSerializer.Serialize(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer, payload));
 
         await _harness.Bus.Publish(new RecurringCancelled(id, recurringId));
 
@@ -113,11 +113,11 @@ public class BotStateMachineRecurringTests : IAsyncLifetime
         
         var payload = new TransferPayload("111111", "001", 12345, "Test");
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "transfer", TransferPayload: payload));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer, TransferPayload: payload));
         var saga = _sagaHarness.Sagas.Contains(id);
 
-        saga.PendingIntentType = "transfer";
-        saga.PendingIntentPayload = JsonSerializer.Serialize(new UserIntentDetected(id, "transfer", TransferPayload: payload));
+        saga.PendingIntentType = Bot.Shared.Enums.IntentType.Transfer;
+        saga.PendingIntentPayload = JsonSerializer.Serialize(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer, TransferPayload: payload));
 
         await _harness.Bus.Publish(new RecurringExecuted(id, Guid.NewGuid()));
         await _harness.Bus.Publish(new RecurringExecuted(id, Guid.NewGuid()));

--- a/Bot.Tests/StateMachine/BotStateMachineSecurityAndEdgeTests.cs
+++ b/Bot.Tests/StateMachine/BotStateMachineSecurityAndEdgeTests.cs
@@ -57,7 +57,7 @@ public class BotStateMachineSecurityAndEdgeTests(ITestOutputHelper testOutputHel
     public async Task EDG_03_Should_Not_Disrupt_Saga_On_IntentEvt_In_Invalid_State()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "EdgeCase"));
 
         var exists = await _sagaHarness.Exists(id, x => x.AskNin, TimeSpan.FromSeconds(5));
@@ -67,7 +67,7 @@ public class BotStateMachineSecurityAndEdgeTests(ITestOutputHelper testOutputHel
         Assert.Equal("AskNin", saga?.CurrentState);
 
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "transfer")); // invalid time
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Transfer)); // invalid time
 
         saga = _sagaHarness.Sagas.Contains(id);
         Assert.Equal("AskNin", saga?.CurrentState); // remains safe
@@ -78,7 +78,7 @@ public class BotStateMachineSecurityAndEdgeTests(ITestOutputHelper testOutputHel
     {
         var id = NewId.NextGuid();
 
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Test User"));
 
         var exists = await _sagaHarness.Exists(id, x => x.AskNin, TimeSpan.FromSeconds(5));
@@ -96,7 +96,7 @@ public class BotStateMachineSecurityAndEdgeTests(ITestOutputHelper testOutputHel
     public async Task EVT_01_Should_Publish_NudgeCmd_On_NinRejected()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Nudge User"));
         await _harness.Bus.Publish(new NinProvided(id, "invalid"));
         await _harness.Bus.Publish(new NinRejected(id, "invalid"));
@@ -109,7 +109,7 @@ public class BotStateMachineSecurityAndEdgeTests(ITestOutputHelper testOutputHel
     public async Task EVT_02_Should_Publish_NudgeCmd_On_BvnRejected()
     {
         var id = NewId.NextGuid();
-        await _harness.Bus.Publish(new UserIntentDetected(id, "signup"));
+        await _harness.Bus.Publish(new UserIntentDetected(id, Bot.Shared.Enums.IntentType.Signup));
         await _harness.Bus.Publish(new FullNameProvided(id, "Nudge User"));
         await _harness.Bus.Publish(new NinProvided(id, "12345678901"));
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));


### PR DESCRIPTION
## Summary
- add `IntentType` enum to centralise valid intents
- use the enum in `UserIntentDetected` event and saga state
- update `NlpService` to map intent strings into enum values
- adjust Bot state machine logic to compare enum intents
- refactor tests to use the new enum
- update EF migration snapshots for the enum column

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*