### PR TITLE
Fix log message in BudgetAlertScheduler

### DIFF
--- a/Bot.Host/BackgroundJobs/BudgetAlertScheduler.cs
+++ b/Bot.Host/BackgroundJobs/BudgetAlertScheduler.cs
@@ -38,7 +38,7 @@ public class BudgetAlertScheduler(
         if (_scheduler != null)
         {
             await _scheduler.Shutdown(cancellationToken);
-            logger.LogInformation("⏹️ BudgetAlertScheduler stopped");
+            logger.LogInformation("⏹ BudgetAlertScheduler stopped");
         }
     }
 }


### PR DESCRIPTION
## Summary
- complete the log message when BudgetAlertScheduler stops

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*