### PR TITLE
Improve correlation handling

### DIFF
--- a/Bot.Core/Services/ConversationStateService.cs
+++ b/Bot.Core/Services/ConversationStateService.cs
@@ -10,6 +10,7 @@ public interface IConversationStateService
 {
     Task<ConversationSession> GetOrCreateSessionAsync(string phoneNumber);
     Task UpdateLastMessageAsync(Guid sessionId, string message);
+    Task SetUserAsync(Guid sessionId, Guid userId);
     Task SetStateAsync(Guid sessionId, string state);
     Task<string> GetStateAsync(Guid sessionId);
 }
@@ -83,6 +84,13 @@ public class ConversationStateService(
     {
         var key = SessionKey(sessionId);
         await _redis.HashSetAsync(key, nameof(ConversationSession.LastMessage), message);
+        await TouchAsync(sessionId);
+    }
+
+    public async Task SetUserAsync(Guid sessionId, Guid userId)
+    {
+        var key = SessionKey(sessionId);
+        await _redis.HashSetAsync(key, nameof(ConversationSession.UserId), userId.ToString());
         await TouchAsync(sessionId);
     }
 

--- a/Bot.Core/Services/NudgeService.cs
+++ b/Bot.Core/Services/NudgeService.cs
@@ -22,7 +22,8 @@ public class NudgeService(ApplicationDbContext db) : INudgeService
         [NudgeType.BadPin] = "https://cdn.bot.ng/nudges/wrong-pin.png",
         [NudgeType.TransferFail] = "https://cdn.bot.ng/nudges/tx-failed.gif",
         [NudgeType.WaitingOnMandate] = "https://cdn.bot.ng/nudges/mandate-wait.gif",
-        [NudgeType.BudgetAlert] = "https://cdn.bot.ng/nudges/limit-near.png"
+        [NudgeType.BudgetAlert] = "https://cdn.bot.ng/nudges/limit-near.png",
+        [NudgeType.SignupRequired] = "https://cdn.bot.ng/nudges/signup-required.png"
     };
 
     private readonly Random _rng = new();

--- a/Bot.Core/Services/UserService.cs
+++ b/Bot.Core/Services/UserService.cs
@@ -10,7 +10,7 @@ namespace Bot.Core.Services;
 
 public interface IUserService
 {
-    Task<User> CreateAsync(SignupPayload payload);
+    Task<User> CreateAsync(Guid userId, SignupPayload payload);
     Task<User?> GetByIdAsync(Guid userId);
     Task SetPersonalityAsync(Guid userId, PersonalityEnum personality);
     Task<bool> RunKycAsync(Guid userId);
@@ -18,11 +18,11 @@ public interface IUserService
 
 public class UserService(ApplicationDbContext db) : IUserService
 {
-    public async Task<User> CreateAsync(SignupPayload p)
+    public async Task<User> CreateAsync(Guid userId, SignupPayload p)
     {
         var user = new User
         {
-            Id = Guid.NewGuid(),
+            Id = userId,
             FullName = p.FullName,
             PhoneNumber = p.Phone,
             NINEnc = Encrypt(p.NIN),

--- a/Bot.Core/StateMachine/BotStateMachine.cs
+++ b/Bot.Core/StateMachine/BotStateMachine.cs
@@ -93,6 +93,12 @@ public class BotStateMachine : MassTransitStateMachine<BotState>
                 .PublishAsync(ctx => Task.FromResult(new PromptFullNameCmd(ctx.Saga.CorrelationId)))
                 .TransitionTo(AskFullName),
 
+            When(IntentEvt, ctx => ctx.Message.Intent is "transfer" or "billpay")
+                .ThenAsync(ctx => ctx.Publish(new NudgeCmd(ctx.Saga.CorrelationId, NudgeType.SignupRequired, ctx.Saga.PhoneNumber, "📝 Please sign up before making transactions.")))
+                .ThenAsync(SetState("AskFullName"))
+                .PublishAsync(ctx => Task.FromResult(new PromptFullNameCmd(ctx.Saga.CorrelationId)))
+                .TransitionTo(AskFullName),
+
             When(IntentEvt, ctx => ctx.Message.Intent == "greeting")
                 .ThenAsync(ctx => ctx.Publish(new NudgeCmd(ctx.Saga.CorrelationId, NudgeType.Greeting, ctx.Saga.PhoneNumber, "👋 Hello! Let me know what you'd like to do next."))),
 
@@ -153,7 +159,15 @@ public class BotStateMachine : MassTransitStateMachine<BotState>
 
         During(AwaitingKyc,
             When(SignOk)
-                .ThenAsync(SetState("AwaitingBankLink"))
+                .ThenAsync(async ctx =>
+                {
+                    await SetState("AwaitingBankLink")(ctx);
+                    var svc = ctx.TryGetPayload<IServiceProvider>(out var sp)
+                        ? sp.GetService<IConversationStateService>()
+                        : null;
+                    if (svc != null)
+                        await svc.SetUserAsync(ctx.Saga.SessionId, ctx.Message.UserId);
+                })
                 .PublishAsync(ctx => Task.FromResult(new KycCmd(ctx.Saga.CorrelationId)))
                 .TransitionTo(AwaitingBankLink),
             When(SignBad)

--- a/Bot.Core/StateMachine/Consumers/Chat/SignupCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/Chat/SignupCmdConsumer.cs
@@ -10,10 +10,10 @@ public class SignupCmdConsumer(IUserService users) : IConsumer<SignupCmd>
     {
         try
         {
-            await users.CreateAsync(ctx.Message.Payload);
-            await ctx.Publish(new SignupSucceeded(ctx.Message.CorrelationId));
+            var user = await users.CreateAsync(ctx.Message.CorrelationId, ctx.Message.Payload);
+            await ctx.Publish(new SignupSucceeded(ctx.Message.CorrelationId, user.Id));
         }
-        catch (Exception e)
+        catch (Exception)
         {
             await ctx.Publish(new SignupFailed(ctx.Message.CorrelationId, "DuplicateOrInvalid"));
             throw;

--- a/Bot.Host/Endpoints/WhatsAppWebhookEndpoint.cs
+++ b/Bot.Host/Endpoints/WhatsAppWebhookEndpoint.cs
@@ -85,7 +85,16 @@ public class WhatsAppWebhookEndpoint(
             };
 
             var session = await state.GetOrCreateSessionAsync(phone);
-            var correlationId = session.UserId != Guid.Empty ? session.UserId : Guid.NewGuid();
+            Guid correlationId;
+            if (session.UserId != Guid.Empty)
+            {
+                correlationId = session.UserId;
+            }
+            else
+            {
+                correlationId = Guid.NewGuid();
+                await state.SetUserAsync(session.SessionId, correlationId);
+            }
 
             var payeeMatch = await db.Payees.AnyAsync(p =>
                 p.UserId == correlationId &&

--- a/Bot.Shared/DTOs/Events.cs
+++ b/Bot.Shared/DTOs/Events.cs
@@ -3,7 +3,7 @@ using Bot.Shared.Enums;
 namespace Bot.Shared.DTOs;
 
 /* onboarding */
-public record SignupSucceeded(Guid CorrelationId);
+public record SignupSucceeded(Guid CorrelationId, Guid UserId);
 
 public record SignupFailed(Guid CorrelationId, string Reason);
 

--- a/Bot.Shared/Payloads.cs
+++ b/Bot.Shared/Payloads.cs
@@ -46,5 +46,6 @@ public enum NudgeType
     InvalidNin,
     WaitingOnMandate,
     Greeting,
-    Unknown
+    Unknown,
+    SignupRequired
 }

--- a/Bot.Tests/StateMachine/BotStateMachineOnboardingTests.cs
+++ b/Bot.Tests/StateMachine/BotStateMachineOnboardingTests.cs
@@ -159,7 +159,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
         await _harness.Bus.Publish(new BvnProvided(id, "12345678901"));
         await _harness.Bus.Publish(new BvnVerified(id, "12345678901"));
-        await _harness.Bus.Publish(new SignupSucceeded(id));
+        await _harness.Bus.Publish(new SignupSucceeded(id, Guid.NewGuid()));
 
         var instance = await _sagaHarness.Exists(id, x => x.AwaitingBankLink, TimeSpan.FromSeconds(5));
         Assert.NotNull(instance);
@@ -178,7 +178,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
         await _harness.Bus.Publish(new BvnProvided(id, "12345678901"));
         await _harness.Bus.Publish(new BvnVerified(id, "12345678901"));
-        await _harness.Bus.Publish(new SignupSucceeded(id));
+        await _harness.Bus.Publish(new SignupSucceeded(id, Guid.NewGuid()));
         await _harness.Bus.Publish(new KycRejected(id, "Failed validation"));
 
         var instance = await _sagaHarness.Exists(id, x => x.Final, TimeSpan.FromSeconds(5));
@@ -216,7 +216,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
         await _harness.Bus.Publish(new BvnProvided(id, "12345678901"));
         await _harness.Bus.Publish(new BvnVerified(id, "12345678901"));
-        await _harness.Bus.Publish(new SignupSucceeded(id));
+        await _harness.Bus.Publish(new SignupSucceeded(id, Guid.NewGuid()));
         await _harness.Bus.Publish(new KycApproved(id));
 
         var instance = await _sagaHarness.Exists(id, x => x.AwaitingBankLink, TimeSpan.FromSeconds(5));
@@ -267,7 +267,7 @@ public class BotStateMachineOnboardingTests(ITestOutputHelper testOutputHelper) 
         await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
         await _harness.Bus.Publish(new BvnProvided(id, "12345678901"));
         await _harness.Bus.Publish(new BvnVerified(id, "12345678901"));
-        await _harness.Bus.Publish(new SignupSucceeded(id));
+        await _harness.Bus.Publish(new SignupSucceeded(id, Guid.NewGuid()));
         await _harness.Bus.Publish(new KycApproved(id));
         await _harness.Bus.Publish(new MandateReadyToDebit(id, "mid", "Mono"));
         await _harness.Bus.Publish(new BankLinkSucceeded(id));

--- a/Bot.Tests/StateMachine/BotStateMachinePinAndIntentTests.cs
+++ b/Bot.Tests/StateMachine/BotStateMachinePinAndIntentTests.cs
@@ -71,7 +71,8 @@ public class BotStateMachinePinAndIntentTests(ITestOutputHelper testOutputHelper
         ));
 
         await _harness.Bus.Publish(new SignupSucceeded(
-            sagaId
+            sagaId,
+            Guid.NewGuid()
         ));
 
         await _harness.Bus.Publish(new MandateReadyToDebit(

--- a/Bot.Tests/TestUtilities/FakeConversationStateService.cs
+++ b/Bot.Tests/TestUtilities/FakeConversationStateService.cs
@@ -12,6 +12,12 @@ public class FakeConversationStateService : IConversationStateService
         return Task.CompletedTask;
     }
 
+    public Task SetUserAsync(Guid sessionId, Guid userId)
+    {
+        Console.WriteLine($"[Fake] Set user {userId} for session {sessionId}");
+        return Task.CompletedTask;
+    }
+
     public Task<ConversationSession> GetOrCreateSessionAsync(string phone)
         => Task.FromResult(new ConversationSession
         {


### PR DESCRIPTION
## Summary
- allow specifying user id when creating a new user
- use the saga correlation id when creating the user record

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*