### PR TITLE
Align user ID with saga ID

### DIFF
--- a/Bot.Core/Services/UserService.cs
+++ b/Bot.Core/Services/UserService.cs
@@ -10,7 +10,7 @@ namespace Bot.Core.Services;
 
 public interface IUserService
 {
-    Task<User> CreateAsync(SignupPayload payload);
+    Task<User> CreateAsync(Guid userId, SignupPayload payload);
     Task<User?> GetByIdAsync(Guid userId);
     Task SetPersonalityAsync(Guid userId, PersonalityEnum personality);
     Task<bool> RunKycAsync(Guid userId);
@@ -18,11 +18,11 @@ public interface IUserService
 
 public class UserService(ApplicationDbContext db) : IUserService
 {
-    public async Task<User> CreateAsync(SignupPayload p)
+    public async Task<User> CreateAsync(Guid userId, SignupPayload p)
     {
         var user = new User
         {
-            Id = Guid.NewGuid(),
+            Id = userId,
             FullName = p.FullName,
             PhoneNumber = p.Phone,
             NINEnc = Encrypt(p.NIN),

--- a/Bot.Core/StateMachine/Consumers/Chat/SignupCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/Chat/SignupCmdConsumer.cs
@@ -10,7 +10,7 @@ public class SignupCmdConsumer(IUserService users) : IConsumer<SignupCmd>
     {
         try
         {
-            await users.CreateAsync(ctx.Message.Payload);
+            await users.CreateAsync(ctx.Message.CorrelationId, ctx.Message.Payload);
             await ctx.Publish(new SignupSucceeded(ctx.Message.CorrelationId));
         }
         catch (Exception e)


### PR DESCRIPTION
## Summary
- accept explicit userId when creating a user
- keep signup saga and user ids identical

## Testing
- `dotnet build -c Release` *(fails: `dotnet: command not found`)*
- `dotnet test` *(fails: `dotnet: command not found`)*