### PR TITLE
Add onboarding prompt consumers

### DIFF
--- a/Bot.Core/StateMachine/Consumers/UX/PromptBvnCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/UX/PromptBvnCmdConsumer.cs
@@ -1,0 +1,17 @@
+using Bot.Core.Services;
+using Bot.Shared.DTOs;
+using MassTransit;
+
+namespace Bot.Core.StateMachine.Consumers.UX;
+
+public class PromptBvnCmdConsumer(IWhatsAppService wa, IUserService users) : IConsumer<PromptBvnCmd>
+{
+    public async Task Consume(ConsumeContext<PromptBvnCmd> ctx)
+    {
+        var user = await users.GetByIdAsync(ctx.Message.CorrelationId);
+        if (user is null)
+            return;
+
+        await wa.SendTextMessageAsync(user.PhoneNumber, "\uD83D\uDD10 Please provide your 11-digit BVN.");
+    }
+}

--- a/Bot.Core/StateMachine/Consumers/UX/PromptFullNameCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/UX/PromptFullNameCmdConsumer.cs
@@ -1,0 +1,17 @@
+using Bot.Core.Services;
+using Bot.Shared.DTOs;
+using MassTransit;
+
+namespace Bot.Core.StateMachine.Consumers.UX;
+
+public class PromptFullNameCmdConsumer(IWhatsAppService wa, IUserService users) : IConsumer<PromptFullNameCmd>
+{
+    public async Task Consume(ConsumeContext<PromptFullNameCmd> ctx)
+    {
+        var user = await users.GetByIdAsync(ctx.Message.CorrelationId);
+        if (user is null)
+            return;
+
+        await wa.SendTextMessageAsync(user.PhoneNumber, "\uD83D\uDC64 What's your full name?");
+    }
+}

--- a/Bot.Core/StateMachine/Consumers/UX/PromptNinCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/UX/PromptNinCmdConsumer.cs
@@ -1,0 +1,17 @@
+using Bot.Core.Services;
+using Bot.Shared.DTOs;
+using MassTransit;
+
+namespace Bot.Core.StateMachine.Consumers.UX;
+
+public class PromptNinCmdConsumer(IWhatsAppService wa, IUserService users) : IConsumer<PromptNinCmd>
+{
+    public async Task Consume(ConsumeContext<PromptNinCmd> ctx)
+    {
+        var user = await users.GetByIdAsync(ctx.Message.CorrelationId);
+        if (user is null)
+            return;
+
+        await wa.SendTextMessageAsync(user.PhoneNumber, "\uD83C\uDD94 Please provide your 11-digit NIN.");
+    }
+}

--- a/Bot.Host/ServiceCollectionExtensions.cs
+++ b/Bot.Host/ServiceCollectionExtensions.cs
@@ -134,6 +134,9 @@ public static class ServiceCollectionExtensions
             x.AddConsumersFromNamespaceContaining<NudgeCmdConsumer>();
             x.AddConsumersFromNamespaceContaining<BalanceCmdConsumer>();
             x.AddConsumersFromNamespaceContaining<StartMandateSetupCmdConsumer>();
+            x.AddConsumersFromNamespaceContaining<PromptFullNameCmdConsumer>();
+            x.AddConsumersFromNamespaceContaining<PromptNinCmdConsumer>();
+            x.AddConsumersFromNamespaceContaining<PromptBvnCmdConsumer>();
             x.AddSagaStateMachine<BotStateMachine, BotState, BotStateMachineDefinition>();
             x.AddSagaStateMachine<DirectDebitMandateStateMachine, DirectDebitMandateState,
                 DirectDebitMandateMachineDefinition>();

--- a/Bot.Tests/Consumers/PromptCmdConsumerTests.cs
+++ b/Bot.Tests/Consumers/PromptCmdConsumerTests.cs
@@ -1,0 +1,72 @@
+using Bot.Core.Services;
+using Bot.Core.StateMachine.Consumers.UX;
+using Bot.Shared.DTOs;
+using Bot.Shared.Models;
+using Moq;
+using MassTransit;
+using Xunit;
+
+namespace Bot.Tests.Consumers;
+
+public class PromptCmdConsumerTests
+{
+    [Fact]
+    public async Task Should_Send_FullName_Prompt()
+    {
+        var wa = new Mock<IWhatsAppService>();
+        var users = new Mock<IUserService>();
+        users.Setup(u => u.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            PhoneNumber = "+2348000000000"
+        });
+
+        var consumer = new PromptFullNameCmdConsumer(wa.Object, users.Object);
+        var cmd = new PromptFullNameCmd(Guid.NewGuid());
+        var ctx = Mock.Of<ConsumeContext<PromptFullNameCmd>>(c => c.Message == cmd);
+
+        await consumer.Consume(ctx);
+
+        wa.Verify(w => w.SendTextMessageAsync("+2348000000000", It.Is<string>(s => s.Contains("full name"))), Times.Once);
+    }
+
+    [Fact]
+    public async Task Should_Send_Nin_Prompt()
+    {
+        var wa = new Mock<IWhatsAppService>();
+        var users = new Mock<IUserService>();
+        users.Setup(u => u.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            PhoneNumber = "+2348000000001"
+        });
+
+        var consumer = new PromptNinCmdConsumer(wa.Object, users.Object);
+        var cmd = new PromptNinCmd(Guid.NewGuid());
+        var ctx = Mock.Of<ConsumeContext<PromptNinCmd>>(c => c.Message == cmd);
+
+        await consumer.Consume(ctx);
+
+        wa.Verify(w => w.SendTextMessageAsync("+2348000000001", It.Is<string>(s => s.Contains("NIN"))), Times.Once);
+    }
+
+    [Fact]
+    public async Task Should_Send_Bvn_Prompt()
+    {
+        var wa = new Mock<IWhatsAppService>();
+        var users = new Mock<IUserService>();
+        users.Setup(u => u.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new User
+        {
+            Id = Guid.NewGuid(),
+            PhoneNumber = "+2348000000002"
+        });
+
+        var consumer = new PromptBvnCmdConsumer(wa.Object, users.Object);
+        var cmd = new PromptBvnCmd(Guid.NewGuid());
+        var ctx = Mock.Of<ConsumeContext<PromptBvnCmd>>(c => c.Message == cmd);
+
+        await consumer.Consume(ctx);
+
+        wa.Verify(w => w.SendTextMessageAsync("+2348000000002", It.Is<string>(s => s.Contains("BVN"))), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add consumers to send signup prompts for full name, NIN and BVN
- register the consumers with MassTransit
- test that each prompt publishes WhatsApp messages

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*