### PR TITLE
Fix correlation ID handling

### DIFF
--- a/Bot.Core/Services/ReferenceGenerator.cs
+++ b/Bot.Core/Services/ReferenceGenerator.cs
@@ -19,7 +19,8 @@ public class ReferenceGenerator : IReferenceGenerator
         var input = $"{userId}:{toAccount}:{bankCode}:{DateTime.UtcNow:yyyyMMddHHmmss}";
         using var sha = SHA256.Create();
         var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(input));
-        return "txn:" + Convert.ToHexString(hash)[..12].ToLower();
+        var shortHash = Convert.ToHexString(hash)[..12].ToLower();
+        return $"txn:{userId}:{shortHash}";
     }
 
     public string GenerateRecurringRef(Guid recurringId)

--- a/Bot.Core/StateMachine/Consumers/UX/PromptBvnCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/UX/PromptBvnCmdConsumer.cs
@@ -4,14 +4,13 @@ using MassTransit;
 
 namespace Bot.Core.StateMachine.Consumers.UX;
 
-public class PromptBvnCmdConsumer(IWhatsAppService wa, IUserService users) : IConsumer<PromptBvnCmd>
+public class PromptBvnCmdConsumer(IWhatsAppService wa, IConversationStateService sessions) : IConsumer<PromptBvnCmd>
 {
     public async Task Consume(ConsumeContext<PromptBvnCmd> ctx)
     {
-        var user = await users.GetByIdAsync(ctx.Message.CorrelationId);
-        if (user is null)
-            return;
+        var session = await sessions.GetSessionByUserAsync(ctx.Message.CorrelationId);
+        if (session is null) return;
 
-        await wa.SendTextMessageAsync(user.PhoneNumber, "\uD83D\uDD10 Please provide your 11-digit BVN.");
+        await wa.SendTextMessageAsync(session.PhoneNumber, "\uD83D\uDD10 Please provide your 11-digit BVN.");
     }
 }

--- a/Bot.Core/StateMachine/Consumers/UX/PromptFullNameCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/UX/PromptFullNameCmdConsumer.cs
@@ -4,14 +4,13 @@ using MassTransit;
 
 namespace Bot.Core.StateMachine.Consumers.UX;
 
-public class PromptFullNameCmdConsumer(IWhatsAppService wa, IUserService users) : IConsumer<PromptFullNameCmd>
+public class PromptFullNameCmdConsumer(IWhatsAppService wa, IConversationStateService sessions) : IConsumer<PromptFullNameCmd>
 {
     public async Task Consume(ConsumeContext<PromptFullNameCmd> ctx)
     {
-        var user = await users.GetByIdAsync(ctx.Message.CorrelationId);
-        if (user is null)
-            return;
+        var session = await sessions.GetSessionByUserAsync(ctx.Message.CorrelationId);
+        if (session is null) return;
 
-        await wa.SendTextMessageAsync(user.PhoneNumber, "\uD83D\uDC64 What's your full name?");
+        await wa.SendTextMessageAsync(session.PhoneNumber, "\uD83D\uDC64 What's your full name?");
     }
 }

--- a/Bot.Core/StateMachine/Consumers/UX/PromptNinCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/UX/PromptNinCmdConsumer.cs
@@ -4,14 +4,13 @@ using MassTransit;
 
 namespace Bot.Core.StateMachine.Consumers.UX;
 
-public class PromptNinCmdConsumer(IWhatsAppService wa, IUserService users) : IConsumer<PromptNinCmd>
+public class PromptNinCmdConsumer(IWhatsAppService wa, IConversationStateService sessions) : IConsumer<PromptNinCmd>
 {
     public async Task Consume(ConsumeContext<PromptNinCmd> ctx)
     {
-        var user = await users.GetByIdAsync(ctx.Message.CorrelationId);
-        if (user is null)
-            return;
+        var session = await sessions.GetSessionByUserAsync(ctx.Message.CorrelationId);
+        if (session is null) return;
 
-        await wa.SendTextMessageAsync(user.PhoneNumber, "\uD83C\uDD94 Please provide your 11-digit NIN.");
+        await wa.SendTextMessageAsync(session.PhoneNumber, "\uD83C\uDD94 Please provide your 11-digit NIN.");
     }
 }

--- a/Bot.Tests/Consumers/PromptCmdConsumerTests.cs
+++ b/Bot.Tests/Consumers/PromptCmdConsumerTests.cs
@@ -1,7 +1,6 @@
 using Bot.Core.Services;
 using Bot.Core.StateMachine.Consumers.UX;
 using Bot.Shared.DTOs;
-using Bot.Shared.Models;
 using Moq;
 using MassTransit;
 using Xunit;
@@ -14,14 +13,17 @@ public class PromptCmdConsumerTests
     public async Task Should_Send_FullName_Prompt()
     {
         var wa = new Mock<IWhatsAppService>();
-        var users = new Mock<IUserService>();
-        users.Setup(u => u.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new User
-        {
-            Id = Guid.NewGuid(),
-            PhoneNumber = "+2348000000000"
-        });
+        var sessions = new Mock<IConversationStateService>();
+        sessions.Setup(s => s.GetSessionByUserAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new ConversationSession
+            {
+                PhoneNumber = "+2348000000000",
+                SessionId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                LastUpdatedUtc = DateTime.UtcNow
+            });
 
-        var consumer = new PromptFullNameCmdConsumer(wa.Object, users.Object);
+        var consumer = new PromptFullNameCmdConsumer(wa.Object, sessions.Object);
         var cmd = new PromptFullNameCmd(Guid.NewGuid());
         var ctx = Mock.Of<ConsumeContext<PromptFullNameCmd>>(c => c.Message == cmd);
 
@@ -34,14 +36,17 @@ public class PromptCmdConsumerTests
     public async Task Should_Send_Nin_Prompt()
     {
         var wa = new Mock<IWhatsAppService>();
-        var users = new Mock<IUserService>();
-        users.Setup(u => u.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new User
-        {
-            Id = Guid.NewGuid(),
-            PhoneNumber = "+2348000000001"
-        });
+        var sessions = new Mock<IConversationStateService>();
+        sessions.Setup(s => s.GetSessionByUserAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new ConversationSession
+            {
+                PhoneNumber = "+2348000000001",
+                SessionId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                LastUpdatedUtc = DateTime.UtcNow
+            });
 
-        var consumer = new PromptNinCmdConsumer(wa.Object, users.Object);
+        var consumer = new PromptNinCmdConsumer(wa.Object, sessions.Object);
         var cmd = new PromptNinCmd(Guid.NewGuid());
         var ctx = Mock.Of<ConsumeContext<PromptNinCmd>>(c => c.Message == cmd);
 
@@ -54,14 +59,17 @@ public class PromptCmdConsumerTests
     public async Task Should_Send_Bvn_Prompt()
     {
         var wa = new Mock<IWhatsAppService>();
-        var users = new Mock<IUserService>();
-        users.Setup(u => u.GetByIdAsync(It.IsAny<Guid>())).ReturnsAsync(new User
-        {
-            Id = Guid.NewGuid(),
-            PhoneNumber = "+2348000000002"
-        });
+        var sessions = new Mock<IConversationStateService>();
+        sessions.Setup(s => s.GetSessionByUserAsync(It.IsAny<Guid>()))
+            .ReturnsAsync(new ConversationSession
+            {
+                PhoneNumber = "+2348000000002",
+                SessionId = Guid.NewGuid(),
+                UserId = Guid.NewGuid(),
+                LastUpdatedUtc = DateTime.UtcNow
+            });
 
-        var consumer = new PromptBvnCmdConsumer(wa.Object, users.Object);
+        var consumer = new PromptBvnCmdConsumer(wa.Object, sessions.Object);
         var cmd = new PromptBvnCmd(Guid.NewGuid());
         var ctx = Mock.Of<ConsumeContext<PromptBvnCmd>>(c => c.Message == cmd);
 

--- a/Bot.Tests/Mappers/WebhookToEventMapperTests.cs
+++ b/Bot.Tests/Mappers/WebhookToEventMapperTests.cs
@@ -12,7 +12,7 @@ public class WebhookToEventMapperTests
         var guid = Guid.NewGuid();
         var json = $$"""
         {
-            "transaction_ref": "txn:{{guid}}",
+            "transaction_ref": "txn:{{guid}}:abcdef123456",
             "transaction_id": "abc123"
         }
         """;
@@ -21,7 +21,7 @@ public class WebhookToEventMapperTests
         var evt = WebhookToEventMapper.MapTransferSuccess(doc.RootElement, "Mono");
 
         evt.CorrelationId.Should().Be(guid);
-        evt.Reference.Should().Be($"txn:{guid}");
+        evt.Reference.Should().Be($"txn:{guid}:abcdef123456");
     }
 
     [Fact]
@@ -30,7 +30,7 @@ public class WebhookToEventMapperTests
         var guid = Guid.NewGuid();
         var json = $$"""
                      {
-            "transaction_ref": "txn:{{guid}}"
+            "transaction_ref": "txn:{{guid}}:deadbeefdead"
         }
         """;
 
@@ -38,7 +38,7 @@ public class WebhookToEventMapperTests
         var evt = WebhookToEventMapper.MapTransferFailed(doc.RootElement);
 
         evt.CorrelationId.Should().Be(guid);
-        evt.Reference.Should().Be($"txn:{guid}");
+        evt.Reference.Should().Be($"txn:{guid}:deadbeefdead");
         evt.Reason.Should().Be("No reason provided");
     }
 
@@ -48,7 +48,7 @@ public class WebhookToEventMapperTests
         var guid = Guid.NewGuid();
         var json = $$"""
         {
-            "transaction_ref": "txn:{{guid}}",
+            "transaction_ref": "txn:{{guid}}:abcdefabcdef",
             "failure_reason": "Insufficient funds"
         }
         """;
@@ -113,7 +113,7 @@ public class WebhookToEventMapperTests
         var guid = Guid.NewGuid();
         var result = typeof(WebhookToEventMapper)
             .GetMethod("GetUserId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
-            .Invoke(null, [$"txn:{guid}"]);
+            .Invoke(null, [$"txn:{guid}:123abc"]);
 
         result.Should().Be(guid);
     }

--- a/Bot.Tests/Services/ReferenceGeneratorTests.cs
+++ b/Bot.Tests/Services/ReferenceGeneratorTests.cs
@@ -19,9 +19,9 @@ public class ReferenceGeneratorTests
         var reference = _generator.GenerateTransferRef(userId, account, bankCode);
 
         // Assert
-        reference.Should().StartWith("txn:");
-        reference.Length.Should().Be(16); // txn: + 12 chars
-        reference.Should().MatchRegex("^txn:[a-z0-9]{12}$");
+        reference.Should().StartWith($"txn:{userId}:");
+        reference.Length.Should().Be($"txn:{userId}:".Length + 12);
+        reference.Should().MatchRegex($"^txn:{userId}:[a-z0-9]{12}$");
     }
 
     [Fact]
@@ -29,8 +29,8 @@ public class ReferenceGeneratorTests
     {
         var reference = _generator.GenerateTransferRef(Guid.Empty, "", "");
 
-        reference.Should().StartWith("txn:");
-        reference.Should().HaveLength(16);
+        reference.Should().StartWith($"txn:{Guid.Empty}:");
+        reference.Length.Should().Be($"txn:{Guid.Empty}:".Length + 12);
     }
 
     [Fact]

--- a/Bot.Tests/TestUtilities/FakeConversationStateService.cs
+++ b/Bot.Tests/TestUtilities/FakeConversationStateService.cs
@@ -1,3 +1,4 @@
+using System;
 using Bot.Core.Services;
 
 namespace Bot.Tests.TestUtilities;
@@ -25,6 +26,16 @@ public class FakeConversationStateService : IConversationStateService
             SessionId = Guid.NewGuid(),
             State = "None",
             UserId = Guid.NewGuid(),
+            LastUpdatedUtc = DateTime.UtcNow
+        });
+
+    public Task<ConversationSession?> GetSessionByUserAsync(Guid userId)
+        => Task.FromResult<ConversationSession?>(new ConversationSession
+        {
+            PhoneNumber = "+2340000000000",
+            SessionId = Guid.NewGuid(),
+            State = "None",
+            UserId = userId,
             LastUpdatedUtc = DateTime.UtcNow
         });
 


### PR DESCRIPTION
## Summary
- embed user ID in transfer reference strings
- expose conversation session lookup by user ID
- use session phone when prompting for onboarding
- update mapper and reference generator tests

## Testing
- `dotnet test` *(fails: command not found)*