### PR TITLE
Add billing service tests and improve sweep logging

### DIFF
--- a/Bot.Core/Services/BillingService.cs
+++ b/Bot.Core/Services/BillingService.cs
@@ -43,6 +43,7 @@ public class BillingService(ApplicationDbContext db, ILogger<BillingService> log
     {
         var unswept = await db.FeeRecords.Where(f => !f.Swept).ToListAsync();
         var total = unswept.Sum(f => f.Amount);
+        var count = unswept.Count;
 
         if (total <= 0)
         {
@@ -56,7 +57,9 @@ public class BillingService(ApplicationDbContext db, ILogger<BillingService> log
         {
             unswept.ForEach(f => f.Swept = true);
             await db.SaveChangesAsync();
-            logger.LogInformation("Swept total fees {Total} to master account", total);
+            logger.LogInformation(
+                "Swept {Count} fee records totaling {Total} to master account",
+                count, total);
         }
         else
         {

--- a/Bot.Tests/Services/BillingServiceTests.cs
+++ b/Bot.Tests/Services/BillingServiceTests.cs
@@ -1,0 +1,67 @@
+using Bot.Core.Services;
+using Bot.Infrastructure.Data;
+using Bot.Shared.Models;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Bot.Tests.Services;
+
+public class BillingServiceTests
+{
+    private ApplicationDbContext CreateDb(string name) =>
+        new(new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options);
+
+    [Fact]
+    public async Task HandleTransferCompletedAsync_Should_Create_Fee_Record()
+    {
+        var db = CreateDb("fee-create");
+        var txId = Guid.NewGuid();
+        db.Transactions.Add(new Transaction
+        {
+            Id = txId,
+            UserId = Guid.NewGuid(),
+            TenantId = Guid.NewGuid(),
+            Amount = 1000m,
+            Reference = "ref",
+            CreatedAt = DateTime.UtcNow,
+            Status = 0
+        });
+        await db.SaveChangesAsync();
+
+        var service = new BillingService(db, Mock.Of<ILogger<BillingService>>());
+        await service.HandleTransferCompletedAsync(txId);
+
+        var record = await db.FeeRecords.FirstOrDefaultAsync(f => f.TransactionId == txId);
+        record.Should().NotBeNull();
+        record!.Amount.Should().Be(50m + 1000m * 0.01m);
+        record.Swept.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SweepFeesAsync_Should_Mark_Fees_As_Swept_And_Log()
+    {
+        var db = CreateDb("fee-sweep");
+        db.FeeRecords.Add(new FeeRecord { Id = Guid.NewGuid(), TransactionId = Guid.NewGuid(), Amount = 10m, CreatedAt = DateTime.UtcNow, Swept = false });
+        db.FeeRecords.Add(new FeeRecord { Id = Guid.NewGuid(), TransactionId = Guid.NewGuid(), Amount = 20m, CreatedAt = DateTime.UtcNow, Swept = false });
+        await db.SaveChangesAsync();
+
+        var logger = new Mock<ILogger<BillingService>>();
+        var service = new BillingService(db, logger.Object);
+
+        await service.SweepFeesAsync();
+
+        var remaining = await db.FeeRecords.CountAsync(f => !f.Swept);
+        remaining.Should().Be(0);
+
+        logger.Verify(l => l.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((o, t) => o.ToString()!.Contains("Swept")),
+            It.IsAny<Exception?>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.AtLeastOnce);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for BillingService
- log count/total when sweeping fees

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*