### PR TITLE
Add unit tests for state machine consumers

### DIFF
--- a/Bot.Tests/Consumers/ChatConsumersTests.cs
+++ b/Bot.Tests/Consumers/ChatConsumersTests.cs
@@ -1,0 +1,206 @@
+using Bot.Core.Services;
+using Bot.Core.StateMachine.Consumers.Chat;
+using Bot.Infrastructure.Data;
+using Bot.Shared.DTOs;
+using Bot.Shared.Enums;
+using Bot.Shared.Models;
+using Bot.Tests.TestUtilities;
+using FluentAssertions;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Bot.Tests.Consumers;
+
+public class ChatConsumersTests
+{
+    [Fact]
+    public async Task BankLinkCmd_Should_Publish_StartMandate()
+    {
+        var userId = Guid.NewGuid();
+        var enc = new Mock<IEncryptionService>();
+        enc.Setup(e => e.Decrypt("bvn")).Returns("12345678901");
+        var userSvc = new Mock<IUserService>();
+        userSvc.Setup(u => u.GetByIdAsync(userId)).ReturnsAsync(new User { Id = userId, PhoneNumber = "234", FullName = "Joe", BVNEnc = "bvn" });
+
+        var harness = await TestContextHelper.BuildTestHarness<BankLinkCmdConsumer>(services =>
+        {
+            services.AddSingleton(userSvc.Object);
+            services.AddSingleton(enc.Object);
+        });
+
+        await harness.Bus.Publish(new BankLinkCmd(userId));
+
+        (await harness.Published.Any<StartMandateSetupCmd>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task KycCmd_Should_Publish_Approved_When_Success()
+    {
+        var userId = Guid.NewGuid();
+        var svc = new Mock<IUserService>();
+        svc.Setup(s => s.RunKycAsync(userId)).ReturnsAsync(true);
+
+        var harness = await TestContextHelper.BuildTestHarness<KycCmdConsumer>(services =>
+        {
+            services.AddSingleton(svc.Object);
+        });
+
+        await harness.Bus.Publish(new KycCmd(userId));
+
+        (await harness.Published.Any<KycApproved>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task NlpFromText_Should_Publish_Detected()
+    {
+        var userId = Guid.NewGuid();
+        var nlp = new Mock<INlpService>();
+        nlp.Setup(n => n.DetectIntentAsync(userId, "hi", "+234")).ReturnsAsync(new UserIntentDetected(userId, IntentType.Greeting));
+
+        var harness = await TestContextHelper.BuildTestHarness<NlpFromTextConsumer>(services =>
+        {
+            services.AddSingleton(nlp.Object);
+        });
+
+        await harness.Bus.Publish(new VoiceMessageTranscribed(userId, "hi", "en", "+234"));
+
+        (await harness.Published.Any<UserIntentDetected>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task PinSetupCmd_Should_Publish_PinSet()
+    {
+        var userId = Guid.NewGuid();
+        var pinSvc = new Mock<IPinService>();
+        var wa = new Mock<IWhatsAppService>();
+        var userSvc = new Mock<IUserService>();
+        userSvc.Setup(u => u.GetByIdAsync(userId)).ReturnsAsync(new User { Id = userId, PhoneNumber = "234" });
+
+        var harness = await TestContextHelper.BuildTestHarness<PinSetupCmdConsumer>(services =>
+        {
+            services.AddSingleton(pinSvc.Object);
+            services.AddSingleton(wa.Object);
+            services.AddSingleton(userSvc.Object);
+        });
+
+        await harness.Bus.Publish(new PinSetupCmd(userId, "1234", "msgId"));
+
+        (await harness.Published.Any<PinSet>()).Should().BeTrue();
+        wa.Verify(w => w.DeleteMessageAsync("msgId"), Times.Once);
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task PinValidationCmd_Should_Publish_Validated_When_Ok()
+    {
+        var userId = Guid.NewGuid();
+        var pinSvc = new Mock<IPinService>();
+        pinSvc.Setup(p => p.ValidateAsync(userId, "1111")).ReturnsAsync(true);
+
+        var harness = await TestContextHelper.BuildTestHarness<PinValidationCmdConsumer>(services =>
+        {
+            services.AddSingleton(pinSvc.Object);
+        });
+
+        await harness.Bus.Publish(new PinValidationCmd(userId, "1111"));
+
+        (await harness.Published.Any<PinValidated>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task RawInboundMsg_Should_Publish_FullNameProvided()
+    {
+        var sessionSvc = new Mock<IConversationStateService>();
+        var session = new ConversationSession { SessionId = Guid.NewGuid(), UserId = Guid.NewGuid(), PhoneNumber = "+234" };
+        sessionSvc.Setup(s => s.GetOrCreateSessionAsync("+234"))
+            .ReturnsAsync(session);
+        sessionSvc.Setup(s => s.GetStateAsync(session.SessionId)).ReturnsAsync("AskFullName");
+
+        var harness = await TestContextHelper.BuildTestHarness<RawInboundMsgCmdConsumer>(services =>
+        {
+            services.AddSingleton(sessionSvc.Object);
+            services.AddSingleton(new Mock<ILogger<RawInboundMsgCmdConsumer>>().Object);
+        });
+
+        await harness.Bus.Publish(new RawInboundMsgCmd(Guid.NewGuid(), "+234", "John", "msg"));
+
+        (await harness.Published.Any<FullNameProvided>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task SetDefaultBankAccountCmd_Should_Update_Accounts()
+    {
+        var userId = Guid.NewGuid();
+        var acc1 = Guid.NewGuid();
+        var acc2 = Guid.NewGuid();
+
+        var harness = await TestContextHelper.BuildTestHarness<SetDefaultBankAccountCmdConsumer>();
+        var db = harness.Scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await db.LinkedBankAccounts.AddAsync(new LinkedBankAccount { Id = acc1, UserId = userId, IsDefault = false });
+        await db.LinkedBankAccounts.AddAsync(new LinkedBankAccount { Id = acc2, UserId = userId, IsDefault = true });
+        await db.SaveChangesAsync();
+
+        await harness.Bus.Publish(new SetDefaultBankAccountCmd(userId, acc1));
+
+        (await db.LinkedBankAccounts.FindAsync(acc1)).IsDefault.Should().BeTrue();
+        (await db.LinkedBankAccounts.FindAsync(acc2)).IsDefault.Should().BeFalse();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task SignupCmd_Should_Publish_Success()
+    {
+        var svc = new Mock<IUserService>();
+        svc.Setup(s => s.CreateAsync(It.IsAny<Guid>(), It.IsAny<SignupPayload>())).ReturnsAsync(new User { Id = Guid.NewGuid() });
+
+        var harness = await TestContextHelper.BuildTestHarness<SignupCmdConsumer>(services =>
+        {
+            services.AddSingleton(svc.Object);
+        });
+
+        await harness.Bus.Publish(new SignupCmd(Guid.NewGuid(), new SignupPayload("a", "b", "c", "d")));
+
+        (await harness.Published.Any<SignupSucceeded>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task ValidateBvnCmd_Should_Publish_Verified()
+    {
+        var svc = new Mock<IIdentityVerificationService>();
+        svc.Setup(s => s.VerifyBvnAsync("1")).ReturnsAsync(true);
+
+        var harness = await TestContextHelper.BuildTestHarness<ValidateBvnCmdConsumer>(services =>
+        {
+            services.AddSingleton(svc.Object);
+        });
+
+        await harness.Bus.Publish(new ValidateBvnCmd(Guid.NewGuid(), "1"));
+
+        (await harness.Published.Any<BvnVerified>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task ValidateNinCmd_Should_Publish_Verified()
+    {
+        var svc = new Mock<IIdentityVerificationService>();
+        svc.Setup(s => s.VerifyNinAsync("1")).ReturnsAsync(true);
+
+        var harness = await TestContextHelper.BuildTestHarness<ValidateNinCmdConsumer>(services =>
+        {
+            services.AddSingleton(svc.Object);
+        });
+
+        await harness.Bus.Publish(new ValidateNinCmd(Guid.NewGuid(), "1"));
+
+        (await harness.Published.Any<NinVerified>()).Should().BeTrue();
+        await harness.Stop();
+    }
+}

--- a/Bot.Tests/Consumers/PaymentConsumersTests.cs
+++ b/Bot.Tests/Consumers/PaymentConsumersTests.cs
@@ -1,0 +1,123 @@
+using Bot.Core.Providers;
+using Bot.Core.Services;
+using Bot.Core.StateMachine.Consumers.Payments;
+using Bot.Infrastructure.Data;
+using Bot.Shared.DTOs;
+using Bot.Shared.Enums;
+using Bot.Shared.Models;
+using Bot.Tests.TestUtilities;
+using FluentAssertions;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Bot.Tests.Consumers;
+
+public class PaymentConsumersTests
+{
+    [Fact]
+    public async Task BalanceCmd_Should_Publish_BalanceSent()
+    {
+        var userId = Guid.NewGuid();
+        var provider = new Mock<IBankProvider>();
+        provider.Setup(p => p.GetBalanceAsync(It.IsAny<string>())).ReturnsAsync(500m);
+
+        var userSvc = new Mock<IUserService>();
+        userSvc.Setup(u => u.GetByIdAsync(userId)).ReturnsAsync(new User { Id = userId, PhoneNumber = "234" });
+
+        var harness = await TestContextHelper.BuildTestHarness<BalanceCmdConsumer>(services =>
+        {
+            services.AddMockBankFactory(userId, provider.Object);
+            services.AddSingleton(userSvc.Object);
+        });
+
+        await harness.Bus.Publish(new BalanceCmd(userId));
+
+        (await harness.Published.Any<BalanceSent>()).Should().BeTrue();
+        var sent = (await harness.Published.SelectAsync<BalanceSent>().First()).Context.Message;
+        sent.UserId.Should().Be(userId);
+        sent.Balance.Should().Be(500m);
+
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task BillPayCmd_Should_Publish_BillPaid_When_Successful()
+    {
+        var userId = Guid.NewGuid();
+        var billSvc = new Mock<IBillPayService>();
+        var billId = Guid.NewGuid();
+        billSvc.Setup(b => b.PayBillAsync(userId, It.IsAny<string>(), It.IsAny<decimal>(), It.IsAny<DateTime>()))
+            .ReturnsAsync(new BillPayment { Id = billId, UserId = userId, IsPaid = true, Biller = BillerEnum.Electricity });
+
+        var userSvc = new Mock<IUserService>();
+        userSvc.Setup(u => u.GetByIdAsync(userId)).ReturnsAsync(new User { Id = userId });
+
+        var harness = await TestContextHelper.BuildTestHarness<BillPayCmdConsumer>(services =>
+        {
+            services.AddSingleton(billSvc.Object);
+            services.AddSingleton(userSvc.Object);
+        });
+
+        await harness.Bus.Publish(new BillPayCmd(userId, new BillPayload("b", "ref", 100m, null)));
+
+        (await harness.Published.Any<BillPaid>()).Should().BeTrue();
+        var evt = (await harness.Published.SelectAsync<BillPaid>().First()).Context.Message;
+        evt.UserId.Should().Be(userId);
+        evt.BillId.Should().Be(billId);
+
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task RecurringCmd_Should_Create_Record_And_Publish()
+    {
+        var userId = Guid.NewGuid();
+
+        var harness = await TestContextHelper.BuildTestHarness<RecurringCmdConsumer>();
+        var db = harness.Scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await db.SeedUserAsync(userId);
+
+        var payload = new RecurringPayload(Guid.NewGuid(), new TransferPayload("123", "001", 50m, null), "*");
+        await harness.Bus.Publish(new RecurringCmd(userId, payload));
+
+        (await harness.Published.Any<RecurringExecuted>()).Should().BeTrue();
+        (await db.RecurringTransfers.CountAsync()).Should().Be(1);
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task RecurringCancelCmd_Should_Set_Inactive()
+    {
+        var userId = Guid.NewGuid();
+        var recId = Guid.NewGuid();
+
+        var harness = await TestContextHelper.BuildTestHarness<RecurringCancelCmdConsumer>();
+        var db = harness.Scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await db.RecurringTransfers.AddAsync(new RecurringTransfer { Id = recId, UserId = userId, IsActive = true });
+        await db.SaveChangesAsync();
+
+        await harness.Bus.Publish(new RecurringCancelCmd(userId, recId));
+
+        (await harness.Published.Any<RecurringCancelled>()).Should().BeTrue();
+        (await db.RecurringTransfers.FindAsync(recId)).IsActive.Should().BeFalse();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task RewardCmd_Should_Call_Service_And_Publish()
+    {
+        var userId = Guid.NewGuid();
+        var svc = new Mock<IRewardService>();
+        var harness = await TestContextHelper.BuildTestHarness<RewardCmdConsumer>(services =>
+        {
+            services.AddSingleton(svc.Object);
+        });
+
+        await harness.Bus.Publish(new RewardCmd(userId, RewardType.Signup));
+
+        svc.Verify(s => s.GrantAsync(userId, RewardType.Signup), Times.Once);
+        (await harness.Published.Any<RewardIssued>()).Should().BeTrue();
+        await harness.Stop();
+    }
+}

--- a/Bot.Tests/Consumers/UxConsumersTests.cs
+++ b/Bot.Tests/Consumers/UxConsumersTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http;
+using Bot.Core.Services;
+using Bot.Core.StateMachine.Consumers.UX;
+using Bot.Infrastructure.Data;
+using Bot.Shared.DTOs;
+using Bot.Shared.Enums;
+using Bot.Tests.TestUtilities;
+using FluentAssertions;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Bot.Tests.Consumers;
+
+public class UxConsumersTests
+{
+    [Fact]
+    public async Task QuickReplyCmd_Should_Send_And_Publish()
+    {
+        var userId = Guid.NewGuid();
+        var wa = new Mock<IWhatsAppService>();
+        var replySvc = new Mock<IQuickReplyService>();
+        replySvc.Setup(r => r.GetQuickRepliesAsync(userId)).ReturnsAsync(["A", "B"]);
+        var userSvc = new Mock<IUserService>();
+        userSvc.Setup(u => u.GetByIdAsync(userId)).ReturnsAsync(new User { Id = userId, PhoneNumber = "234" });
+
+        var harness = await TestContextHelper.BuildTestHarness<QuickReplyCmdConsumer>(services =>
+        {
+            services.AddSingleton(wa.Object);
+            services.AddSingleton(replySvc.Object);
+            services.AddSingleton(userSvc.Object);
+        });
+
+        await harness.Bus.Publish(new QuickReplyCmd(userId, "tmpl"));
+
+        wa.Verify(w => w.SendQuickReplyAsync("234", "Your top payees", It.IsAny<string>(), It.IsAny<string[]>()), Times.Once);
+        (await harness.Published.Any<QuickReplySent>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task NudgeCmd_Should_Publish_NudgeSent()
+    {
+        var wa = new Mock<IWhatsAppService>();
+        var nudges = new Mock<INudgeService>();
+        nudges.Setup(n => n.SelectAsset(NudgeType.TransferFail)).Returns("asset");
+
+        var harness = await TestContextHelper.BuildTestHarness<NudgeCmdConsumer>(services =>
+        {
+            services.AddSingleton(wa.Object);
+            services.AddSingleton(nudges.Object);
+            services.AddSingleton(new Mock<IUserService>().Object);
+        });
+
+        await harness.Bus.Publish(new NudgeCmd(Guid.NewGuid(), NudgeType.TransferFail, "+234", "text"));
+
+        wa.Verify(w => w.SendTextMessageAsync("+234", "text"), Times.Once);
+        (await harness.Published.Any<NudgeSent>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task VoiceMessageCmd_Should_Publish_Transcribed()
+    {
+        var speech = new Mock<ISpeechService>();
+        speech.Setup(s => s.TranscribeAsync(It.IsAny<Stream>())).ReturnsAsync(("hi", "en"));
+        var handler = new MockHttpMessageHandler("data");
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        var harness = await TestContextHelper.BuildTestHarness<VoiceMessageCmdConsumer>(services =>
+        {
+            services.AddSingleton(speech.Object);
+            services.AddSingleton(factory.Object);
+        });
+
+        await harness.Bus.Publish(new VoiceMessageCmd(Guid.NewGuid(), "url", "+234"));
+
+        (await harness.Published.Any<VoiceMessageTranscribed>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task ImageUploadedCmd_Should_Publish_OcrResult()
+    {
+        var ocr = new Mock<IOcrService>();
+        ocr.Setup(o => o.ExtractTextAsync(It.IsAny<Stream>())).ReturnsAsync("text");
+        var handler = new MockHttpMessageHandler("img");
+        var client = new HttpClient(handler);
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+        var harness = await TestContextHelper.BuildTestHarness<ImageUploadedCmdConsumer>(services =>
+        {
+            services.AddSingleton(ocr.Object);
+            services.AddSingleton(factory.Object);
+        });
+
+        await harness.Bus.Publish(new ImageUploadedCmd(Guid.NewGuid(), "url", "+234"));
+
+        (await harness.Published.Any<OcrResultAvailable>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task ResolveQuickReplyCmd_Should_Publish_UserIntent_When_Found()
+    {
+        var userId = Guid.NewGuid();
+        var harness = await TestContextHelper.BuildTestHarness<ResolveQuickReplyCmdConsumer>();
+        var db = harness.Scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        await db.Payees.AddAsync(new Payee { Id = Guid.NewGuid(), UserId = userId, AccountNumber = "1", BankCode = "001", Nickname = "joe" });
+        await db.SaveChangesAsync();
+
+        await harness.Bus.Publish(new ResolveQuickReplyCmd(userId, "joe"));
+
+        (await harness.Published.Any<UserIntentDetected>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task RespondWithVoiceCmd_Should_Publish_VoiceReplyReady()
+    {
+        var tts = new Mock<ITextToSpeechService>();
+        tts.Setup(t => t.SynthesizeAsync("hi", "en")).ReturnsAsync(new MemoryStream());
+
+        var harness = await TestContextHelper.BuildTestHarness<RespondWithVoiceCmdConsumer>(services =>
+        {
+            services.AddSingleton(tts.Object);
+        });
+
+        await harness.Bus.Publish(new RespondWithVoiceCmd(Guid.NewGuid(), "hi", "en"));
+
+        (await harness.Published.Any<VoiceReplyReady>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task FeedbackCmd_Should_Publish_Logged()
+    {
+        var svc = new Mock<IFeedbackService>();
+        svc.Setup(f => f.StoreAsync(It.IsAny<Guid>(), It.IsAny<FeedbackPayload>())).ReturnsAsync(Guid.NewGuid());
+
+        var harness = await TestContextHelper.BuildTestHarness<FeedbackCmdConsumer>(services =>
+        {
+            services.AddSingleton(svc.Object);
+        });
+
+        await harness.Bus.Publish(new FeedbackCmd(Guid.NewGuid(), new FeedbackPayload(5, "ok")));
+
+        (await harness.Published.Any<FeedbackLogged>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    [Fact]
+    public async Task MemoCmd_Should_Publish_MemoSaved()
+    {
+        var svc = new Mock<IMemoService>();
+        svc.Setup(m => m.SaveAsync(It.IsAny<Guid>(), It.IsAny<MemoPayload>())).ReturnsAsync(Guid.NewGuid());
+
+        var harness = await TestContextHelper.BuildTestHarness<MemoCmdConsumer>(services =>
+        {
+            services.AddSingleton(svc.Object);
+        });
+
+        await harness.Bus.Publish(new MemoCmd(Guid.NewGuid(), new MemoPayload(Guid.NewGuid(), "memo", null)));
+
+        (await harness.Published.Any<MemoSaved>()).Should().BeTrue();
+        await harness.Stop();
+    }
+
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _content;
+        public MockHttpMessageHandler(string content) => _content = content;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(_content) });
+    }
+}


### PR DESCRIPTION
## Summary
- add PaymentConsumersTests covering Balance, BillPay, Recurring and Reward flows
- add UxConsumersTests for UX related consumers like quick replies, nudges and voice replies
- add ChatConsumersTests covering chat command handlers

## Testing
- `dotnet test --no-build --nologo --verbosity quiet` *(fails: `dotnet: command not found`)*