### PR TITLE
Add helper utility tests

### DIFF
--- a/Bot.Tests/Helpers/BVNValidatorTests.cs
+++ b/Bot.Tests/Helpers/BVNValidatorTests.cs
@@ -1,0 +1,25 @@
+using Bot.Core.StateMachine.Helpers;
+using FluentAssertions;
+
+namespace Bot.Tests.Helpers;
+
+public class BVNValidatorTests
+{
+    [Theory]
+    [InlineData("12345678901", true)]
+    [InlineData("1234567890", false)]
+    [InlineData("1234567890a", false)]
+    public void IsValid_Should_Validate_Bvn_Format(string input, bool expected)
+    {
+        BvnValidator.IsValid(input).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("12345678901", true)]
+    [InlineData("1234567890", false)]
+    [InlineData("1234567890a", false)]
+    public void IsNinValid_Should_Validate_Nin_Format(string input, bool expected)
+    {
+        BvnValidator.IsNinValid(input).Should().Be(expected);
+    }
+}

--- a/Bot.Tests/Helpers/HttpJsonLoggerTests.cs
+++ b/Bot.Tests/Helpers/HttpJsonLoggerTests.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using System.Net.Http;
+using Bot.Core.StateMachine.Helpers;
+using Bot.Tests.TestUtilities;
+using FluentAssertions;
+
+namespace Bot.Tests.Helpers;
+
+public class HttpJsonLoggerTests
+{
+    [Fact]
+    public async Task LogRequest_Should_Log_Method_Uri_And_Body()
+    {
+        var logger = new ListLogger();
+        var req = new HttpRequestMessage(HttpMethod.Post, "https://example.com/api")
+        {
+            Content = new StringContent("{\"x\":1}")
+        };
+
+        await HttpJsonLogger.LogRequest(req, logger);
+
+        logger.Entries.Should().HaveCount(1);
+        logger.Entries[0].Message.Should().Contain("POST").And.Contain("https://example.com/api").And.Contain("{\"x\":1}");
+    }
+
+    [Fact]
+    public async Task LogResponse_Should_Log_Status_And_Body()
+    {
+        var logger = new ListLogger();
+        var res = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            ReasonPhrase = "OK",
+            Content = new StringContent("pong")
+        };
+
+        await HttpJsonLogger.LogResponse(res, logger);
+
+        logger.Entries.Should().HaveCount(1);
+        logger.Entries[0].Message.Should().Contain("200").And.Contain("OK").And.Contain("pong");
+    }
+}

--- a/Bot.Tests/Helpers/PhoneUtilTests.cs
+++ b/Bot.Tests/Helpers/PhoneUtilTests.cs
@@ -1,0 +1,35 @@
+using Bot.Core.StateMachine.Helpers;
+using FluentAssertions;
+
+namespace Bot.Tests.Helpers;
+
+public class PhoneUtilTests
+{
+    [Fact]
+    public void Normalize_Should_Handle_Plus234_Prefix()
+    {
+        var result = PhoneUtil.Normalize("+2348012345678");
+        result.Should().Be("+2348012345678");
+    }
+
+    [Fact]
+    public void Normalize_Should_Add_Plus_For_234_Prefix()
+    {
+        var result = PhoneUtil.Normalize("2348012345678");
+        result.Should().Be("+2348012345678");
+    }
+
+    [Fact]
+    public void Normalize_Should_Convert_Local_Number()
+    {
+        var result = PhoneUtil.Normalize("0801 234-5678");
+        result.Should().Be("+2348012345678");
+    }
+
+    [Fact]
+    public void Normalize_Should_Return_Raw_For_Unknown_Format()
+    {
+        var result = PhoneUtil.Normalize("123456789");
+        result.Should().Be("123456789");
+    }
+}

--- a/Bot.Tests/Helpers/SessionHelperTests.cs
+++ b/Bot.Tests/Helpers/SessionHelperTests.cs
@@ -1,0 +1,33 @@
+using Bot.Core.Services;
+using Bot.Core.StateMachine.Helpers;
+using FluentAssertions;
+using Moq;
+
+namespace Bot.Tests.Helpers;
+
+public class SessionHelperTests
+{
+    [Fact]
+    public async Task SetSessionState_Should_Forward_To_Service()
+    {
+        var svc = new Mock<IConversationStateService>();
+        var id = Guid.NewGuid();
+
+        await SessionHelper.SetSessionState(svc.Object, id, "Ready");
+
+        svc.Verify(s => s.SetStateAsync(id, "Ready"), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetSessionState_Should_Forward_To_Service()
+    {
+        var svc = new Mock<IConversationStateService>();
+        var id = Guid.NewGuid();
+        svc.Setup(s => s.GetStateAsync(id)).ReturnsAsync("Ready");
+
+        var state = await SessionHelper.GetSessionState(svc.Object, id);
+
+        state.Should().Be("Ready");
+        svc.Verify(s => s.GetStateAsync(id), Times.Once);
+    }
+}

--- a/Bot.Tests/TestUtilities/ListLogger.cs
+++ b/Bot.Tests/TestUtilities/ListLogger.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging;
+
+namespace Bot.Tests.TestUtilities;
+
+public class ListLogger : ILogger
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = new();
+
+    public IDisposable BeginScope<TState>(TState state) => NullDisposable.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add((logLevel, formatter(state, exception)));
+    }
+
+    private class NullDisposable : IDisposable
+    {
+        public static readonly NullDisposable Instance = new();
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
## Summary
- add BVNValidator helper tests
- add PhoneUtil helper tests
- add SessionHelper wrapper tests
- add HttpJsonLogger logging tests
- add simple ListLogger for capturing log output in tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet` not found)*