### PR TITLE
Add mocks and unit tests for OCR and speech services

### DIFF
--- a/Bot.Core/Services/DocumentAnalysisClientWrapper.cs
+++ b/Bot.Core/Services/DocumentAnalysisClientWrapper.cs
@@ -1,0 +1,19 @@
+using Azure;
+using Azure.AI.FormRecognizer.DocumentAnalysis;
+
+namespace Bot.Core.Services;
+
+public interface IDocumentAnalysisClient
+{
+    Task<IEnumerable<string>> ExtractLinesAsync(Stream stream);
+}
+
+public class DocumentAnalysisClientWrapper(DocumentAnalysisClient client) : IDocumentAnalysisClient
+{
+    public async Task<IEnumerable<string>> ExtractLinesAsync(Stream stream)
+    {
+        var operation = await client.AnalyzeDocumentAsync(WaitUntil.Completed, "prebuilt-read", stream);
+        var result = operation.Value;
+        return result.Pages.SelectMany(p => p.Lines).Select(l => l.Content);
+    }
+}

--- a/Bot.Core/Services/OcrService.cs
+++ b/Bot.Core/Services/OcrService.cs
@@ -8,13 +8,11 @@ public interface IOcrService
     Task<string> ExtractTextAsync(Stream stream);
 }
 
-public class OcrService(DocumentAnalysisClient client) : IOcrService
+public class OcrService(IDocumentAnalysisClient client) : IOcrService
 {
     public async Task<string> ExtractTextAsync(Stream stream)
     {
-        var operation = await client.AnalyzeDocumentAsync(WaitUntil.Completed, "prebuilt-read", stream);
-        var result = operation.Value;
-
-        return string.Join(" ", result.Pages.SelectMany(p => p.Lines).Select(l => l.Content));
+        var lines = await client.ExtractLinesAsync(stream);
+        return string.Join(" ", lines);
     }
 }

--- a/Bot.Host/ServiceCollectionExtensions.cs
+++ b/Bot.Host/ServiceCollectionExtensions.cs
@@ -70,10 +70,11 @@ public static class ServiceCollectionExtensions
             .AddScoped<IReferenceGenerator, ReferenceGenerator>()
             .AddScoped<IChatClientWrapper, ChatClientWrapper>()
             .AddMemoryCache()
-            .AddScoped<DocumentAnalysisClient>(sp =>
+            .AddScoped<IDocumentAnalysisClient>(sp =>
             {
                 var config = sp.GetRequiredService<IOptions<FormRecognizerOptions>>().Value;
-                return new DocumentAnalysisClient(new Uri(config.Endpoint), new AzureKeyCredential(config.ApiKey));
+                var client = new DocumentAnalysisClient(new Uri(config.Endpoint), new AzureKeyCredential(config.ApiKey));
+                return new DocumentAnalysisClientWrapper(client);
             })
             .AddStackExchangeRedisCache(options =>
             {

--- a/Bot.Tests/Services/OcrServiceTests.cs
+++ b/Bot.Tests/Services/OcrServiceTests.cs
@@ -1,0 +1,23 @@
+using Bot.Core.Services;
+using FluentAssertions;
+using Moq;
+
+namespace Bot.Tests.Services;
+
+public class OcrServiceTests
+{
+    [Fact]
+    public async Task ExtractTextAsync_Joins_Lines()
+    {
+        var mockClient = new Mock<IDocumentAnalysisClient>();
+        mockClient.Setup(x => x.ExtractLinesAsync(It.IsAny<Stream>()))
+            .ReturnsAsync(new[] { "hello", "world" });
+
+        var service = new OcrService(mockClient.Object);
+        await using var ms = new MemoryStream(new byte[] {1,2,3});
+        var result = await service.ExtractTextAsync(ms);
+
+        result.Should().Be("hello world");
+    }
+}
+

--- a/Bot.Tests/Services/TextToSpeechServiceTests.cs
+++ b/Bot.Tests/Services/TextToSpeechServiceTests.cs
@@ -1,0 +1,38 @@
+using Bot.Core.Services;
+using Bot.Infrastructure.Configuration;
+using FluentAssertions;
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Bot.Tests.Services;
+
+public class TextToSpeechServiceTests
+{
+    [Fact]
+    public async Task SynthesizeAsync_Returns_Audio_Stream()
+    {
+        var audio = new byte[] {0x1, 0x2};
+        var mockSynth = new Mock<ISpeechSynthesizer>();
+        mockSynth.Setup(s => s.SpeakTextAsync("hello"))
+            .ReturnsAsync(new SynthesisResult(ResultReason.SynthesizingAudioCompleted, audio));
+        mockSynth.Setup(s => s.GetVoicesAsync())
+            .ReturnsAsync(Array.Empty<VoiceInfo>());
+        mockSynth.Setup(s => s.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        var factory = new Mock<ISpeechSynthesizerFactory>();
+        factory.Setup(f => f.Create(It.IsAny<SpeechConfig>())).Returns(mockSynth.Object);
+
+        var cache = new MemoryCache(new MemoryCacheOptions());
+        var opts = Options.Create(new TextToSpeechOptions {SubscriptionKey = "k", Region = "r"});
+        var service = new TextToSpeechService(cache, opts, factory.Object, _ => "voice");
+
+        var stream = await service.SynthesizeAsync("hello", "en-US");
+        var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer);
+
+        buffer.ToArray().Should().BeEquivalentTo(audio);
+    }
+}
+

--- a/Bot.Tests/Services/TranscriptionServiceTests.cs
+++ b/Bot.Tests/Services/TranscriptionServiceTests.cs
@@ -1,0 +1,30 @@
+using Bot.Core.Services;
+using FluentAssertions;
+using Microsoft.CognitiveServices.Speech;
+using Moq;
+
+namespace Bot.Tests.Services;
+
+public class TranscriptionServiceTests
+{
+    [Fact]
+    public async Task TranscribeAsync_Returns_Text_And_Language()
+    {
+        var recogResult = new RecognitionResult(ResultReason.RecognizedSpeech, "hi", "en-US");
+        var mockRecognizer = new Mock<ISpeechRecognizer>();
+        mockRecognizer.Setup(r => r.RecognizeOnceAsync()).ReturnsAsync(recogResult);
+        mockRecognizer.Setup(r => r.DisposeAsync()).Returns(ValueTask.CompletedTask);
+
+        var factory = new Mock<ISpeechRecognizerFactory>();
+        factory.Setup(f => f.Create(It.IsAny<SpeechConfig>(), It.IsAny<AutoDetectSourceLanguageConfig>(), It.IsAny<AudioConfig>()))
+            .Returns(mockRecognizer.Object);
+
+        var service = new TranscriptionService("key", "region", factory.Object);
+        await using var ms = new MemoryStream(new byte[] {1,2,3});
+        var result = await service.TranscribeAsync(ms, new[] {"en-US"});
+
+        result.Text.Should().Be("hi");
+        result.DetectedLanguage.Should().Be("en-US");
+    }
+}
+


### PR DESCRIPTION
## Summary
- make OCR service depend on an interface for the Azure client
- add factories and wrappers for speech recognition and synthesis
- support mocking in transcription and text-to-speech services
- register new wrappers in DI
- add unit tests for OCR, transcription and text-to-speech services

## Testing
- `dotnet test` *(fails: `dotnet` not found)*