### PR TITLE
Add integration tests for flow scenarios

### DIFF
--- a/Bot.Tests/Integration/BillPayFlowTests.cs
+++ b/Bot.Tests/Integration/BillPayFlowTests.cs
@@ -1,6 +1,135 @@
+using Bot.Core.Services;
+using Bot.Core.StateMachine;
+using Bot.Core.StateMachine.Consumers.Payments;
+using Bot.Infrastructure.Data;
+using Bot.Shared.DTOs;
+using Bot.Shared.Enums;
+using Bot.Shared.Models;
+using MassTransit.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
 namespace Bot.Tests.Integration;
 
-public class BillPayFlowTests
+public class BillPayFlowTests : IAsyncLifetime
 {
-    
+    private ServiceProvider _provider = null!;
+    private ITestHarness _harness = null!;
+    private ISagaStateMachineTestHarness<BotStateMachine, BotState> _sagaHarness = null!;
+    private ApplicationDbContext _db = null!;
+    private readonly Mock<IConversationStateService> _stateSvc = new();
+
+    private class FakeBillPayService : IBillPayService
+    {
+        private readonly ApplicationDbContext _db;
+        public FakeBillPayService(ApplicationDbContext db) => _db = db;
+
+        public Task<IReadOnlyList<BillPayment>> ProcessDueBillPaymentsAsync() =>
+            Task.FromResult<IReadOnlyList<BillPayment>>(Array.Empty<BillPayment>());
+
+        public async Task<BillPayment> PayBillAsync(Guid userId, string billerCode, decimal amount, DateTime dueDate)
+        {
+            var bill = new BillPayment
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Biller = Enum.Parse<BillerEnum>(billerCode),
+                Amount = amount,
+                DueDate = dueDate,
+                IsPaid = true,
+                CreatedAt = DateTime.UtcNow,
+                PaidAt = DateTime.UtcNow
+            };
+            _db.BillPayments.Add(bill);
+            await _db.SaveChangesAsync();
+            return bill;
+        }
+    }
+
+    public async Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+
+        services.AddInMemoryDb("billpay-flow");
+        services.AddMassTransitTestHarness(cfg =>
+        {
+            cfg.AddSagaStateMachine<BotStateMachine, BotState>()
+               .InMemoryRepository();
+            cfg.AddConsumer<BillPayCmdConsumer>();
+        });
+
+        services.AddScoped<BillPayCmdConsumer>();
+        services.AddScoped<IUserService, UserService>();
+        services.AddSingleton<IBillPayService, FakeBillPayService>();
+        services.AddSingleton<IConversationStateService>(_stateSvc.Object);
+
+        _provider = services.BuildServiceProvider(true);
+
+        _harness = _provider.GetRequiredService<ITestHarness>();
+        _sagaHarness = _provider.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
+        _db = _provider.GetRequiredService<ApplicationDbContext>();
+
+        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        _stateSvc.Setup(x => x.SetUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
+
+        await _harness.Start();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_harness != null) await _harness.Stop();
+        if (_provider is IAsyncDisposable disp) await disp.DisposeAsync();
+    }
+
+    private async Task<Guid> SeedReadyAsync(Guid userId)
+    {
+        await _db.SeedUserAsync(userId);
+        var sid = NewId.NextGuid();
+
+        await _harness.Bus.Publish(new UserIntentDetected(sid, IntentType.Signup,
+            SignupPayload: new SignupPayload("User", "+2348000000000", "12345678901", "12345678901")));
+        await _sagaHarness.Exists(sid, x => x.NinValidating, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new NinVerified(sid, "12345678901"));
+        await _sagaHarness.Exists(sid, x => x.AskBvn, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BvnProvided(sid, "12345678901"));
+        await _sagaHarness.Exists(sid, x => x.BvnValidating, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BvnVerified(sid, "12345678901"));
+        await _sagaHarness.Exists(sid, x => x.AwaitingKyc, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new SignupSucceeded(sid, userId));
+        await _sagaHarness.Exists(sid, x => x.AwaitingBankLink, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new MandateReadyToDebit(sid, "mandate", "Mono"));
+        await _sagaHarness.Exists(sid, x => x.AwaitingPinSetup, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BankLinkSucceeded(sid));
+        await _sagaHarness.Exists(sid, x => x.AwaitingPinValidate, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new PinSet(sid));
+        await _sagaHarness.Exists(sid, x => x.Ready, TimeSpan.FromSeconds(5));
+        return sid;
+    }
+
+    [Fact]
+    public async Task Should_Pay_Bill_And_Record()
+    {
+        var userId = Guid.NewGuid();
+        var sid = await SeedReadyAsync(userId);
+
+        var payload = new BillPayload("Electricity", "12345", 4500, "Electricity");
+        await _harness.Bus.Publish(new UserIntentDetected(sid, IntentType.BillPay, BillPayload: payload));
+        await _sagaHarness.Exists(sid, x => x.AwaitingPinValidate, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new PinValidated(sid));
+        await _sagaHarness.Exists(sid, x => x.Ready, TimeSpan.FromSeconds(5));
+
+        Assert.True(await _harness.Published.Any<BillPayCmd>(x => x.Context.Message.CorrelationId == sid));
+        var bill = await _db.BillPayments.FirstOrDefaultAsync();
+        Assert.NotNull(bill);
+        Assert.True(bill!.IsPaid);
+    }
 }

--- a/Bot.Tests/Integration/OnboardingFlowTests.cs
+++ b/Bot.Tests/Integration/OnboardingFlowTests.cs
@@ -1,6 +1,81 @@
+using Bot.Core.Services;
+using Bot.Core.StateMachine;
+using Bot.Infrastructure.Data;
+using Bot.Shared.DTOs;
+using Bot.Shared.Enums;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
 namespace Bot.Tests.Integration;
 
-public class OnboardingFlowTests
+public class OnboardingFlowTests : IAsyncLifetime
 {
-    
+    private ServiceProvider _provider = null!;
+    private ITestHarness _harness = null!;
+    private ISagaStateMachineTestHarness<BotStateMachine, BotState> _sagaHarness = null!;
+    private readonly Mock<IConversationStateService> _stateSvc = new();
+
+    public async Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+
+        services.AddInMemoryDb("onboarding-flow");
+        services.AddMassTransitTestHarness(cfg =>
+        {
+            cfg.AddSagaStateMachine<BotStateMachine, BotState>()
+               .InMemoryRepository();
+        });
+
+        services.AddSingleton<IConversationStateService>(_stateSvc.Object);
+
+        _provider = services.BuildServiceProvider(true);
+        _harness = _provider.GetRequiredService<ITestHarness>();
+        _sagaHarness = _provider.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
+
+        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        _stateSvc.Setup(x => x.SetUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
+
+        await _harness.Start();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_harness != null) await _harness.Stop();
+        if (_provider is IAsyncDisposable disp) await disp.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Should_Reaching_Ready_State_On_Happy_Path()
+    {
+        var id = NewId.NextGuid();
+        var userId = Guid.NewGuid();
+
+        await _harness.Bus.Publish(new UserIntentDetected(id, IntentType.Signup,
+            SignupPayload: new SignupPayload("Jane Doe", "+2348110000000", "12345678901", "12345678901")));
+        await _sagaHarness.Exists(id, x => x.NinValidating, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new NinVerified(id, "12345678901"));
+        await _sagaHarness.Exists(id, x => x.AskBvn, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BvnProvided(id, "12345678901"));
+        await _sagaHarness.Exists(id, x => x.BvnValidating, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BvnVerified(id, "12345678901"));
+        await _sagaHarness.Exists(id, x => x.AwaitingKyc, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new SignupSucceeded(id, userId));
+        await _sagaHarness.Exists(id, x => x.AwaitingBankLink, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new MandateReadyToDebit(id, "mandate", "Mono"));
+        await _sagaHarness.Exists(id, x => x.AwaitingPinSetup, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BankLinkSucceeded(id));
+        await _sagaHarness.Exists(id, x => x.AwaitingPinValidate, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new PinSet(id));
+        var final = await _sagaHarness.Exists(id, x => x.Ready, TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(final);
+    }
 }

--- a/Bot.Tests/Integration/TransferFlowTests.cs
+++ b/Bot.Tests/Integration/TransferFlowTests.cs
@@ -1,6 +1,141 @@
+using Bot.Core.Providers;
+using Bot.Core.Services;
+using Bot.Core.StateMachine;
+using Bot.Core.StateMachine.Consumers.Payments;
+using Bot.Infrastructure.Data;
+using Bot.Shared.DTOs;
+using Bot.Shared.Enums;
+using Bot.Shared.Models;
+using Bot.Tests.TestUtilities;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
 namespace Bot.Tests.Integration;
 
-public class TransferFlowTests
+public class TransferFlowTests : IAsyncLifetime
 {
-    
+    private ServiceProvider _provider = null!;
+    private ITestHarness _harness = null!;
+    private ISagaStateMachineTestHarness<BotStateMachine, BotState> _sagaHarness = null!;
+    private ApplicationDbContext _db = null!;
+    private readonly Mock<IConversationStateService> _stateSvc = new();
+    private readonly Mock<IBankProvider> _bank = new();
+
+    public async Task InitializeAsync()
+    {
+        var services = new ServiceCollection();
+
+        services.AddInMemoryDb("transfer-flow");
+        services.AddMassTransitTestHarness(cfg =>
+        {
+            cfg.AddSagaStateMachine<BotStateMachine, BotState>()
+               .InMemoryRepository();
+            cfg.AddConsumer<TransferCmdConsumer>();
+            cfg.AddConsumer<TransferWebhookHandler>();
+        });
+
+        services.AddScoped<TransferCmdConsumer>();
+        services.AddScoped<TransferWebhookHandler>();
+
+        services.AddSingleton<IConversationStateService>(_stateSvc.Object);
+        services.AddSingleton<IWhatsAppService>(new Mock<IWhatsAppService>().Object);
+        services.AddSingleton<IReferenceGenerator>(sp =>
+        {
+            var m = new Mock<IReferenceGenerator>();
+            m.Setup(r => r.GenerateTransferRef(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns("TX-REF");
+            return m.Object;
+        });
+        services.AddSingleton<IBankProviderFactory>(sp =>
+        {
+            var mock = new Mock<IBankProviderFactory>();
+            mock.Setup(f => f.GetProviderAsync(It.IsAny<Guid>(), It.IsAny<Guid?>()))
+                .ReturnsAsync(_bank.Object);
+            return mock.Object;
+        });
+
+        _provider = services.BuildServiceProvider(true);
+
+        _harness = _provider.GetRequiredService<ITestHarness>();
+        _sagaHarness = _provider.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
+        _db = _provider.GetRequiredService<ApplicationDbContext>();
+
+        _stateSvc.Setup(s => s.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+        _stateSvc.Setup(s => s.SetUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>()))
+            .Returns(Task.CompletedTask);
+
+        await _harness.Start();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_harness != null) await _harness.Stop();
+        if (_provider is IAsyncDisposable disp) await disp.DisposeAsync();
+    }
+
+    private async Task<Guid> SeedReadyAsync(Guid userId)
+    {
+        await _db.SeedUserAsync(userId);
+        await _db.SeedMandateAsync(userId, "mandate-1");
+        var sid = NewId.NextGuid();
+
+        await _harness.Bus.Publish(new UserIntentDetected(sid, IntentType.Signup,
+            SignupPayload: new SignupPayload("Test", "+2348000000000", "12345678901", "12345678901")));
+        await _sagaHarness.Exists(sid, x => x.NinValidating, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new NinVerified(sid, "12345678901"));
+        await _sagaHarness.Exists(sid, x => x.AskBvn, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BvnProvided(sid, "12345678901"));
+        await _sagaHarness.Exists(sid, x => x.BvnValidating, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BvnVerified(sid, "12345678901"));
+        await _sagaHarness.Exists(sid, x => x.AwaitingKyc, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new SignupSucceeded(sid, userId));
+        await _sagaHarness.Exists(sid, x => x.AwaitingBankLink, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new MandateReadyToDebit(sid, "mandate-1", "Mono"));
+        await _sagaHarness.Exists(sid, x => x.AwaitingPinSetup, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new BankLinkSucceeded(sid));
+        await _sagaHarness.Exists(sid, x => x.AwaitingPinValidate, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new PinSet(sid));
+        await _sagaHarness.Exists(sid, x => x.Ready, TimeSpan.FromSeconds(5));
+        return sid;
+    }
+
+    [Fact]
+    public async Task Should_Complete_Transfer_Flow()
+    {
+        var userId = Guid.NewGuid();
+        var sid = await SeedReadyAsync(userId);
+
+        var payload = new TransferPayload("111111", "001", 5000, "Test");
+        await _harness.Bus.Publish(new UserIntentDetected(sid, IntentType.Transfer, TransferPayload: payload));
+        await _sagaHarness.Exists(sid, x => x.AwaitingPinValidate, TimeSpan.FromSeconds(5));
+
+        await _harness.Bus.Publish(new PinValidated(sid));
+        await _sagaHarness.Exists(sid, x => x.Ready, TimeSpan.FromSeconds(5));
+
+        var cmd = _harness.Published.Select<TransferCmd>()
+            .FirstOrDefault(x => x.Context.Message.CorrelationId == sid);
+        Assert.NotNull(cmd);
+
+        var tx = await _db.Transactions.FirstOrDefaultAsync(t => t.Reference == "TX-REF");
+        Assert.NotNull(tx);
+        Assert.Equal(TransactionStatus.Pending, tx!.Status);
+
+        await _harness.Bus.Publish(new TransferCompleted(sid, "TX-REF"));
+        await _harness.InactivityTask;
+
+        tx = await _db.Transactions.FirstAsync(t => t.Reference == "TX-REF");
+        Assert.Equal(TransactionStatus.Success, tx.Status);
+        Assert.True(await _harness.Published.Any<PreviewCmd>(x => x.Context.Message.CorrelationId == sid));
+    }
 }


### PR DESCRIPTION
## Summary
- implement integration tests for onboarding, transfer, bill pay and recurring flows
- use MassTransit test harness with in-memory EF Core

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*