### PR TITLE
Add job tests

### DIFF
--- a/Bot.Host/BackgroundJobs/RecurringTransferJob.cs
+++ b/Bot.Host/BackgroundJobs/RecurringTransferJob.cs
@@ -13,8 +13,14 @@ public class RecurringTransferJob(
     {
         log.LogInformation("RecurringTransferJob started at {Time}", context.FireTimeUtc);
 
-        await recurringService.ProcessDueTransfersAsync();
-
-        log.LogInformation("RecurringTransferJob completed at {Time}", DateTime.UtcNow);
+        try
+        {
+            await recurringService.ProcessDueTransfersAsync();
+            log.LogInformation("RecurringTransferJob completed at {Time}", DateTime.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "RecurringTransferJob failed.");
+        }
     }
 }

--- a/Bot.Tests/BackgroundJobs/FeeSweepJobTests.cs
+++ b/Bot.Tests/BackgroundJobs/FeeSweepJobTests.cs
@@ -1,0 +1,46 @@
+using Bot.Host.BackgroundJobs;
+using Bot.Core.Services;
+using Moq;
+using Quartz;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Bot.Tests.BackgroundJobs;
+
+public class FeeSweepJobTests
+{
+    [Fact]
+    public async Task Execute_Calls_SweepFeesAsync()
+    {
+        var service = new Mock<IBillingService>();
+        var logger = new Mock<ILogger<FeeSweepJob>>();
+        var job = new FeeSweepJob(service.Object, logger.Object);
+        var context = new Mock<IJobExecutionContext>();
+        context.SetupGet(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+
+        await job.Execute(context.Object);
+
+        service.Verify(s => s.SweepFeesAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_Logs_Error_On_Exception()
+    {
+        var service = new Mock<IBillingService>();
+        service.Setup(s => s.SweepFeesAsync()).ThrowsAsync(new Exception("fail"));
+        var logger = new Mock<ILogger<FeeSweepJob>>();
+        var job = new FeeSweepJob(service.Object, logger.Object);
+        var context = new Mock<IJobExecutionContext>();
+        context.SetupGet(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+
+        await job.Execute(context.Object);
+
+        logger.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+}

--- a/Bot.Tests/BackgroundJobs/RecurringTransferJobTests.cs
+++ b/Bot.Tests/BackgroundJobs/RecurringTransferJobTests.cs
@@ -1,0 +1,46 @@
+using Bot.Host.BackgroundJobs;
+using Bot.Core.Services;
+using Moq;
+using Quartz;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Bot.Tests.BackgroundJobs;
+
+public class RecurringTransferJobTests
+{
+    [Fact]
+    public async Task Execute_Calls_ProcessDueTransfersAsync()
+    {
+        var service = new Mock<IRecurringTransferService>();
+        var logger = new Mock<ILogger<RecurringTransferJob>>();
+        var job = new RecurringTransferJob(service.Object, logger.Object);
+        var context = new Mock<IJobExecutionContext>();
+        context.SetupGet(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+
+        await job.Execute(context.Object);
+
+        service.Verify(s => s.ProcessDueTransfersAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Execute_Logs_Error_On_Exception()
+    {
+        var service = new Mock<IRecurringTransferService>();
+        service.Setup(s => s.ProcessDueTransfersAsync()).ThrowsAsync(new Exception("fail"));
+        var logger = new Mock<ILogger<RecurringTransferJob>>();
+        var job = new RecurringTransferJob(service.Object, logger.Object);
+        var context = new Mock<IJobExecutionContext>();
+        context.SetupGet(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+
+        await job.Execute(context.Object);
+
+        logger.Verify(l => l.Log(
+            LogLevel.Error,
+            It.IsAny<EventId>(),
+            It.IsAny<It.IsAnyType>(),
+            It.IsAny<Exception?>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for background jobs
- handle exceptions in RecurringTransferJob

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: `dotnet: command not found`)*