### PR TITLE
Add TwilioMessageSender REST client tests

### DIFF
--- a/Bot.Core/Services/TwilioMessageSender.cs
+++ b/Bot.Core/Services/TwilioMessageSender.cs
@@ -1,3 +1,4 @@
+using Twilio.Clients;
 using Twilio.Rest.Api.V2010.Account;
 using Twilio.Types;
 
@@ -10,11 +11,22 @@ public interface ITwilioMessageSender
 
 public class TwilioMessageSender : ITwilioMessageSender
 {
+    private readonly ITwilioRestClient _client;
+
+    public TwilioMessageSender(ITwilioRestClient client)
+    {
+        _client = client;
+    }
+
     public async Task<string> SendAsync(string from, string to, string body)
     {
-        var msg = await MessageResource.CreateAsync(body: body,
-            from: new PhoneNumber(from),
-            to: new PhoneNumber(to));
+        var options = new CreateMessageOptions(new PhoneNumber(to))
+        {
+            From = new PhoneNumber(from),
+            Body = body
+        };
+
+        var msg = await MessageResource.CreateAsync(options, _client);
         return msg.Sid;
     }
 }

--- a/Bot.Tests/Services/TwilioMessageSenderTests.cs
+++ b/Bot.Tests/Services/TwilioMessageSenderTests.cs
@@ -1,0 +1,48 @@
+using System.Net;
+using Bot.Core.Services;
+using FluentAssertions;
+using Moq;
+using Twilio.Clients;
+using Twilio.Http;
+using Xunit;
+
+namespace Bot.Tests.Services;
+
+public class TwilioMessageSenderTests
+{
+    [Fact]
+    public async Task SendAsync_Should_Use_RestClient_And_Return_Sid()
+    {
+        // Arrange
+        var captured = default(Request);
+        var sid = "SM123";
+        var client = new Mock<ITwilioRestClient>();
+        client.Setup(c => c.RequestAsync(It.IsAny<Request>()))
+            .Callback<Request>(r => captured = r)
+            .ReturnsAsync(new Response(HttpStatusCode.Created, $"{{\"sid\":\"{sid}\"}}"));
+
+        var sender = new TwilioMessageSender(client.Object);
+
+        // Act
+        var result = await sender.SendAsync("+1111", "+2222", "hello");
+
+        // Assert
+        result.Should().Be(sid);
+        captured.Should().NotBeNull();
+        captured.PostParams["From"].Should().Be("+1111");
+        captured.PostParams["To"].Should().Be("+2222");
+        captured.PostParams["Body"].Should().Be("hello");
+    }
+
+    [Fact]
+    public async Task SendAsync_Should_Propagate_Exception()
+    {
+        var client = new Mock<ITwilioRestClient>();
+        client.Setup(c => c.RequestAsync(It.IsAny<Request>()))
+            .ThrowsAsync(new InvalidOperationException("fail"));
+
+        var sender = new TwilioMessageSender(client.Object);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sender.SendAsync("+1", "+2", "msg"));
+    }
+}


### PR DESCRIPTION
## Summary
- inject `ITwilioRestClient` into `TwilioMessageSender`
- add unit tests for `TwilioMessageSender`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*