### PR TITLE
Add RedisService unit tests with mocks

### DIFF
--- a/Bot.Infrastructure/Caching/RedisService.cs
+++ b/Bot.Infrastructure/Caching/RedisService.cs
@@ -7,9 +7,13 @@ public class RedisService
     private readonly IDatabase _db;
 
     public RedisService(RedisConfiguration config)
+        : this(ConnectionMultiplexer.Connect(config.ConnectionString))
     {
-        var mux = ConnectionMultiplexer.Connect(config.ConnectionString);
-        _db = mux.GetDatabase();
+    }
+
+    public RedisService(IConnectionMultiplexer connection)
+    {
+        _db = connection.GetDatabase();
     }
 
     public async Task SetAsync(string key, string value, TimeSpan? expiry = null)

--- a/Bot.Tests/Caching/RedisServiceTests.cs
+++ b/Bot.Tests/Caching/RedisServiceTests.cs
@@ -1,0 +1,94 @@
+using Bot.Infrastructure.Caching;
+using FluentAssertions;
+using Moq;
+using StackExchange.Redis;
+
+namespace Bot.Tests.Caching;
+
+public class RedisServiceTests
+{
+    private class RedisMock
+    {
+        public Mock<IConnectionMultiplexer> Connection { get; } = new();
+        public Mock<IDatabase> Database { get; } = new();
+        public Dictionary<string, RedisValue> Strings { get; } = new();
+        public Dictionary<string, TimeSpan?> Expirations { get; } = new();
+
+        public RedisMock()
+        {
+            Connection.Setup(c => c.GetDatabase(It.IsAny<int>(), It.IsAny<object?>()))
+                .Returns(Database.Object);
+
+            Database.Setup(d => d.StringSetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<TimeSpan?>(), It.IsAny<When>(), It.IsAny<CommandFlags>()))
+                .Callback((RedisKey key, RedisValue val, TimeSpan? exp, When _, CommandFlags __) =>
+                {
+                    Strings[key] = val;
+                    if (exp != null)
+                        Expirations[key] = exp;
+                    else
+                        Expirations.Remove(key);
+                })
+                .ReturnsAsync(true);
+
+            Database.Setup(d => d.StringGetAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                .Returns((RedisKey key, CommandFlags _) =>
+                {
+                    return Task.FromResult(Strings.TryGetValue(key, out var val) ? val : RedisValue.Null);
+                });
+
+            Database.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                .Callback((RedisKey key, CommandFlags _) =>
+                {
+                    Strings.Remove(key);
+                    Expirations.Remove(key);
+                })
+                .ReturnsAsync(true);
+        }
+    }
+
+    private static RedisService CreateService(RedisMock mock)
+    {
+        return new RedisService(mock.Connection.Object);
+    }
+
+    [Fact]
+    public async Task SetAsync_Should_Store_Value_With_Optional_Expiry()
+    {
+        var redis = new RedisMock();
+        var service = CreateService(redis);
+
+        var ttl = TimeSpan.FromSeconds(30);
+        await service.SetAsync("a", "1", ttl);
+        redis.Strings["a"].Should().Be("1");
+        redis.Expirations["a"].Should().Be(ttl);
+
+        await service.SetAsync("b", "2");
+        redis.Strings["b"].Should().Be("2");
+        redis.Expirations.ContainsKey("b").Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GetAsync_Should_Retrieve_Stored_Value()
+    {
+        var redis = new RedisMock();
+        var service = CreateService(redis);
+
+        await service.SetAsync("key", "val");
+        var result = await service.GetAsync("key");
+
+        result.Should().Be("val");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Should_Remove_Key()
+    {
+        var redis = new RedisMock();
+        var service = CreateService(redis);
+
+        await service.SetAsync("k", "v");
+        await service.DeleteAsync("k");
+
+        redis.Strings.ContainsKey("k").Should().BeFalse();
+        redis.Expirations.ContainsKey("k").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- allow injecting `IConnectionMultiplexer` into `RedisService`
- add tests for `RedisService` verifying Set/Get/Delete using mocks

## Testing
- `dotnet test Bot.Tests/Bot.Tests.csproj --no-build --verbosity minimal` *(fails: `dotnet` not found)*