### PR TITLE
Add health endpoint tests

### DIFF
--- a/Bot.Tests/Bot.Tests.csproj
+++ b/Bot.Tests/Bot.Tests.csproj
@@ -16,6 +16,7 @@
         <PackageReference Include="FluentAssertions" Version="8.2.0" />
         <PackageReference Include="MassTransit.TestFramework" Version="8.4.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
+        <PackageReference Include="FastEndpoints.Testing" Version="6.1.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="xunit" Version="2.9.3" />

--- a/Bot.Tests/Endpoints/HealthEndpointTests.cs
+++ b/Bot.Tests/Endpoints/HealthEndpointTests.cs
@@ -1,0 +1,30 @@
+using System.Net;
+using System.Net.Http.Json;
+using Bot.Host.Endpoints;
+using FastEndpoints.Testing;
+using FluentAssertions;
+using Xunit;
+
+namespace Bot.Tests.Endpoints;
+
+public class HealthEndpointTests : IClassFixture<TestApp<Program>>
+{
+    private readonly HttpClient _client;
+
+    public HealthEndpointTests(TestApp<Program> app)
+    {
+        _client = app.Client;
+    }
+
+    [Theory]
+    [InlineData("/health")]
+    [InlineData("/healthz")]
+    public async Task Health_Endpoints_Return_Healthy(string url)
+    {
+        var response = await _client.GetAsync(url);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<HealthResponse>();
+        body.Should().NotBeNull();
+        body!.Status.Should().Be("Healthy");
+    }
+}


### PR DESCRIPTION
## Summary
- add `HealthEndpointTests` using FastEndpoints test host
- add `FastEndpoints.Testing` package reference for test project

## Testing
- `dotnet test Bot.Tests/Bot.Tests.csproj -c Release` *(fails: `dotnet` command not found)*