### PR TITLE
Add QuickReplyOptions default test

### DIFF
--- a/Bot.Tests/Models/QuickReplyOptionsTests.cs
+++ b/Bot.Tests/Models/QuickReplyOptionsTests.cs
@@ -1,0 +1,17 @@
+using Bot.Core.Models;
+using FluentAssertions;
+
+namespace Bot.Tests.Models;
+
+public class QuickReplyOptionsTests
+{
+    [Fact]
+    public void Constructor_Should_Set_Default_Values()
+    {
+        var opts = new QuickReplyOptions();
+
+        opts.MaxFavorites.Should().Be(3);
+        opts.RedisKeyPrefix.Should().Be("qr:");
+        opts.DefaultTemplates.Should().Equal("Check balance", "Send money", "Help");
+    }
+}


### PR DESCRIPTION
## Summary
- add unit test for `QuickReplyOptions` constructor defaults

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*