### PR TITLE
Add missing SetAsync exception test

### DIFF
--- a/Bot.Tests/Services/PinServiceTests.cs
+++ b/Bot.Tests/Services/PinServiceTests.cs
@@ -104,4 +104,12 @@ public class PinServiceTests
 
         isValid.Should().BeFalse();
     }
+
+    [Fact]
+    public async Task SetAsync_Should_Throw_When_UserNotFound()
+    {
+        var act = () => _service.SetAsync(Guid.NewGuid(), "0000");
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
 }


### PR DESCRIPTION
## Summary
- cover `PinService.SetAsync` scenario when user is not found

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*