### PR TITLE
Use ConversationState enum

### DIFF
--- a/Bot.Core/Services/ConversationStateService.cs
+++ b/Bot.Core/Services/ConversationStateService.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
+using Bot.Shared.Enums;
 
 namespace Bot.Core.Services;
 
@@ -12,8 +13,8 @@ public interface IConversationStateService
     Task<ConversationSession?> GetSessionByUserAsync(Guid userId);
     Task UpdateLastMessageAsync(Guid sessionId, string message);
     Task SetUserAsync(Guid sessionId, Guid userId);
-    Task SetStateAsync(Guid sessionId, string state);
-    Task<string> GetStateAsync(Guid sessionId);
+    Task SetStateAsync(Guid sessionId, ConversationState state);
+    Task<ConversationState> GetStateAsync(Guid sessionId);
 }
 
 public class ConversationSession
@@ -21,7 +22,7 @@ public class ConversationSession
     public Guid SessionId { get; set; }
     public Guid UserId { get; set; }
     public string PhoneNumber { get; set; } = null!;
-    public string State { get; set; } = "None";
+    public ConversationState State { get; set; } = ConversationState.None;
     public string? LastMessage { get; set; }
     public DateTime LastUpdatedUtc { get; set; }
 }
@@ -61,7 +62,7 @@ public class ConversationStateService(
             new(nameof(ConversationSession.SessionId), newId.ToString()),
             new(nameof(ConversationSession.UserId), Guid.Empty.ToString()),
             new(nameof(ConversationSession.PhoneNumber), phoneNumber),
-            new(nameof(ConversationSession.State), "None"),
+            new(nameof(ConversationSession.State), ConversationState.None.ToString()),
             new(nameof(ConversationSession.LastUpdatedUtc), now.ToString("o"))
         };
 
@@ -109,18 +110,20 @@ public class ConversationStateService(
         await TouchAsync(sessionId);
     }
 
-    public async Task SetStateAsync(Guid sessionId, string state)
+    public async Task SetStateAsync(Guid sessionId, ConversationState state)
     {
         var key = SessionKey(sessionId);
-        await _redis.HashSetAsync(key, nameof(ConversationSession.State), state);
+        await _redis.HashSetAsync(key, nameof(ConversationSession.State), state.ToString());
         await TouchAsync(sessionId);
     }
 
-    public async Task<string> GetStateAsync(Guid sessionId)
+    public async Task<ConversationState> GetStateAsync(Guid sessionId)
     {
         var key = SessionKey(sessionId);
         var state = await _redis.HashGetAsync(key, nameof(ConversationSession.State));
-        return state.IsNullOrEmpty ? "None" : state!;
+        if (state.IsNullOrEmpty)
+            return ConversationState.None;
+        return Enum.TryParse<ConversationState>(state!, out var result) ? result : ConversationState.None;
     }
 
     private string UserIndexKey(Guid userId)
@@ -141,12 +144,16 @@ public class ConversationStateService(
     private ConversationSession Map(HashEntry[] hash)
     {
         var dict = hash.ToStringDictionary();
+        var stateStr = dict[nameof(ConversationSession.State)];
+        var state = Enum.TryParse<ConversationState>(stateStr, out var parsed)
+            ? parsed
+            : ConversationState.None;
         return new ConversationSession
         {
             SessionId = Guid.Parse(dict[nameof(ConversationSession.SessionId)]),
             UserId = Guid.Parse(dict[nameof(ConversationSession.UserId)]),
             PhoneNumber = dict[nameof(ConversationSession.PhoneNumber)],
-            State = dict[nameof(ConversationSession.State)],
+            State = state,
             LastMessage = dict.GetValueOrDefault(nameof(ConversationSession.LastMessage)),
             LastUpdatedUtc = DateTime.Parse(dict[nameof(ConversationSession.LastUpdatedUtc)])
         };

--- a/Bot.Core/StateMachine/Consumers/Chat/RawInboundMsgCmdConsumer.cs
+++ b/Bot.Core/StateMachine/Consumers/Chat/RawInboundMsgCmdConsumer.cs
@@ -1,5 +1,6 @@
 using Bot.Core.Services;
 using Bot.Shared.DTOs;
+using Bot.Shared.Enums;
 using MassTransit;
 using Microsoft.Extensions.Logging;
 
@@ -17,16 +18,16 @@ public class RawInboundMsgCmdConsumer(IConversationStateService session, ILogger
 
         switch (state)
         {
-            case "AskFullName":
+            case ConversationState.AskFullName:
                 await ctx.Publish(new FullNameProvided(correlationId, text));
                 break;
-            case "AskNin":
+            case ConversationState.AskNin:
                 await ctx.Publish(new NinProvided(correlationId, text));
                 break;
-            case "AskBvn":
+            case ConversationState.AskBvn:
                 await ctx.Publish(new BvnProvided(correlationId, text));
                 break;
-            case "AwaitingPinSetup":
+            case ConversationState.AwaitingPinSetup:
                 await ctx.Publish(new PinSetupCmd(correlationId, text, ctx.Message.MessageId));
                 break;
             default:

--- a/Bot.Core/StateMachine/Helpers/SessionHelper.cs
+++ b/Bot.Core/StateMachine/Helpers/SessionHelper.cs
@@ -1,15 +1,16 @@
 using Bot.Core.Services;
+using Bot.Shared.Enums;
 
 namespace Bot.Core.StateMachine.Helpers;
 
 public static class SessionHelper
 {
-    public static async Task SetSessionState(this IConversationStateService svc, Guid sessionId, string state)
+    public static async Task SetSessionState(this IConversationStateService svc, Guid sessionId, ConversationState state)
     {
         await svc.SetStateAsync(sessionId, state);
     }
 
-    public static Task<string> GetSessionState(this IConversationStateService svc, Guid sessionId)
+    public static Task<ConversationState> GetSessionState(this IConversationStateService svc, Guid sessionId)
     {
         return svc.GetStateAsync(sessionId);
     }

--- a/Bot.Shared/Enums/ConversationState.cs
+++ b/Bot.Shared/Enums/ConversationState.cs
@@ -1,0 +1,16 @@
+namespace Bot.Shared.Enums;
+
+public enum ConversationState
+{
+    None,
+    AskFullName,
+    AskNin,
+    NinValidating,
+    AskBvn,
+    BvnValidating,
+    AwaitingKyc,
+    AwaitingBankLink,
+    AwaitingPinSetup,
+    AwaitingPinValidate,
+    Ready
+}

--- a/Bot.Tests/Consumers/ChatConsumersTests.cs
+++ b/Bot.Tests/Consumers/ChatConsumersTests.cs
@@ -124,7 +124,7 @@ public class ChatConsumersTests
             { SessionId = Guid.NewGuid(), UserId = Guid.NewGuid(), PhoneNumber = "+234" };
         sessionSvc.Setup(s => s.GetOrCreateSessionAsync("+234"))
             .ReturnsAsync(session);
-        sessionSvc.Setup(s => s.GetStateAsync(session.SessionId)).ReturnsAsync("AskFullName");
+        sessionSvc.Setup(s => s.GetStateAsync(session.SessionId)).ReturnsAsync(ConversationState.AskFullName);
 
         var harness = await TestContextHelper.BuildTestHarness<RawInboundMsgCmdConsumer>(services =>
         {

--- a/Bot.Tests/Helpers/SessionHelperTests.cs
+++ b/Bot.Tests/Helpers/SessionHelperTests.cs
@@ -1,5 +1,6 @@
 using Bot.Core.Services;
 using Bot.Core.StateMachine.Helpers;
+using Bot.Shared.Enums;
 using FluentAssertions;
 using Moq;
 
@@ -13,9 +14,9 @@ public class SessionHelperTests
         var svc = new Mock<IConversationStateService>(MockBehavior.Strict);
         var id = Guid.NewGuid();
 
-        svc.Setup(s => s.SetStateAsync(id, "Ready")).Returns(Task.CompletedTask).Verifiable();
+        svc.Setup(s => s.SetStateAsync(id, ConversationState.Ready)).Returns(Task.CompletedTask).Verifiable();
 
-        await svc.Object.SetSessionState(id, "Ready");
+        await svc.Object.SetSessionState(id, ConversationState.Ready);
 
         svc.Verify();
     }
@@ -25,11 +26,11 @@ public class SessionHelperTests
     {
         var svc = new Mock<IConversationStateService>(MockBehavior.Strict);
         var id = Guid.NewGuid();
-        svc.Setup(s => s.GetStateAsync(id)).ReturnsAsync("Ready").Verifiable();
+        svc.Setup(s => s.GetStateAsync(id)).ReturnsAsync(ConversationState.Ready).Verifiable();
 
         var state = await svc.Object.GetSessionState(id);
 
-        state.Should().Be("Ready");
+        state.Should().Be(ConversationState.Ready);
         svc.Verify();
     }
 }

--- a/Bot.Tests/Integration/BillPayFlowTests.cs
+++ b/Bot.Tests/Integration/BillPayFlowTests.cs
@@ -70,7 +70,7 @@ public class BillPayFlowTests : IAsyncLifetime
         _harness = scoped.GetRequiredService<ITestHarness>();
         _sagaHarness = scoped.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
 
-        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<ConversationState>())).Returns(Task.CompletedTask);
         _stateSvc.Setup(x => x.SetUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
 
         await _harness.Start();

--- a/Bot.Tests/Integration/OnboardingFlowTests.cs
+++ b/Bot.Tests/Integration/OnboardingFlowTests.cs
@@ -37,7 +37,7 @@ public class OnboardingFlowTests : IAsyncLifetime
         _harness = _provider.GetRequiredService<ITestHarness>();
         _sagaHarness = _provider.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
 
-        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<ConversationState>())).Returns(Task.CompletedTask);
         _stateSvc.Setup(x => x.SetUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
 
         await _harness.Start();

--- a/Bot.Tests/Integration/RecurringFlowTests.cs
+++ b/Bot.Tests/Integration/RecurringFlowTests.cs
@@ -69,7 +69,7 @@ public class RecurringFlowTests : IAsyncLifetime
         _harness = scoped.GetRequiredService<ITestHarness>();
         _sagaHarness = scoped.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
 
-        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<ConversationState>())).Returns(Task.CompletedTask);
         _stateSvc.Setup(x => x.SetUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
 
         await _harness.Start();

--- a/Bot.Tests/Integration/TransferFlowTests.cs
+++ b/Bot.Tests/Integration/TransferFlowTests.cs
@@ -71,7 +71,7 @@ public class TransferFlowTests : IAsyncLifetime
         _harness = scoped.GetRequiredService<ITestHarness>();
         _sagaHarness = scoped.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
 
-        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>())).Returns(Task.CompletedTask);
+        _stateSvc.Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<ConversationState>())).Returns(Task.CompletedTask);
         _stateSvc.Setup(x => x.SetUserAsync(It.IsAny<Guid>(), It.IsAny<Guid>())).Returns(Task.CompletedTask);
 
         await _harness.Start();

--- a/Bot.Tests/Services/ConversationStateServiceTests.cs
+++ b/Bot.Tests/Services/ConversationStateServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using StackExchange.Redis;
+using Bot.Shared.Enums;
 
 namespace Bot.Tests.Services;
 
@@ -56,9 +57,9 @@ public class ConversationStateServiceTests
         redis.Expirations[sessKey].Should().Be(opts.SessionTtl);
         redis.Expirations[idxKey].Should().Be(opts.SessionTtl);
 
-        var state = "Ready";
+        var state = ConversationState.Ready;
         await service.SetStateAsync(session.SessionId, state);
-        redis.Hashes[sessKey][nameof(ConversationSession.State)].Should().Be(state);
+        redis.Hashes[sessKey][nameof(ConversationSession.State)].Should().Be(state.ToString());
         redis.Expirations[sessKey].Should().Be(opts.SessionTtl);
 
         var msg = "hi";

--- a/Bot.Tests/StateMachine/BotStateMachinePinAndIntentTests.cs
+++ b/Bot.Tests/StateMachine/BotStateMachinePinAndIntentTests.cs
@@ -44,7 +44,7 @@ public class BotStateMachinePinAndIntentTests(ITestOutputHelper testOutputHelper
         _sagaHarness = _provider.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
 
         _stateServiceMock
-            .Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<ConversationState>()))
             .Returns(Task.CompletedTask);
 
         _stateServiceMock

--- a/Bot.Tests/StateMachine/BotStateMachineWebhookTests.cs
+++ b/Bot.Tests/StateMachine/BotStateMachineWebhookTests.cs
@@ -33,7 +33,7 @@ public class BotStateMachineWebhookTests : IAsyncLifetime
         _sagaHarness = _provider.GetRequiredService<ISagaStateMachineTestHarness<BotStateMachine, BotState>>();
 
         _stateServiceMock
-            .Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<string>()))
+            .Setup(x => x.SetStateAsync(It.IsAny<Guid>(), It.IsAny<ConversationState>()))
             .Returns(Task.CompletedTask);
 
         _stateServiceMock

--- a/Bot.Tests/TestUtilities/FakeConversationStateService.cs
+++ b/Bot.Tests/TestUtilities/FakeConversationStateService.cs
@@ -1,15 +1,16 @@
 using Bot.Core.Services;
+using Bot.Shared.Enums;
 
 namespace Bot.Tests.TestUtilities;
 
 public class FakeConversationStateService : IConversationStateService
 {
-    public Task<string> GetStateAsync(Guid sessionId)
+    public Task<ConversationState> GetStateAsync(Guid sessionId)
     {
-        return Task.FromResult("Ready");
+        return Task.FromResult(ConversationState.Ready);
     }
 
-    public Task SetStateAsync(Guid sessionId, string state)
+    public Task SetStateAsync(Guid sessionId, ConversationState state)
     {
         Console.WriteLine($"[Fake] Set session {sessionId} to {state}");
         return Task.CompletedTask;
@@ -27,7 +28,7 @@ public class FakeConversationStateService : IConversationStateService
         {
             PhoneNumber = phone,
             SessionId = Guid.NewGuid(),
-            State = "None",
+            State = ConversationState.None,
             UserId = Guid.NewGuid(),
             LastUpdatedUtc = DateTime.UtcNow
         });
@@ -39,7 +40,7 @@ public class FakeConversationStateService : IConversationStateService
         {
             PhoneNumber = "+2340000000000",
             SessionId = Guid.NewGuid(),
-            State = "None",
+            State = ConversationState.None,
             UserId = userId,
             LastUpdatedUtc = DateTime.UtcNow
         });


### PR DESCRIPTION
## Summary
- add `ConversationState` enum
- refactor conversation session & service to store enum states
- update state helpers and consumers to use enum
- adjust state machine calls and tests

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*