### PR TITLE
Refactor service options and interfaces

### DIFF
--- a/Bot.Core/Models/ConversationSession.cs
+++ b/Bot.Core/Models/ConversationSession.cs
@@ -1,0 +1,11 @@
+namespace Bot.Core.Models;
+
+public class ConversationSession
+{
+    public Guid SessionId { get; set; }
+    public Guid UserId { get; set; }
+    public string PhoneNumber { get; set; } = null!;
+    public string State { get; set; } = "None";
+    public string? LastMessage { get; set; }
+    public DateTime LastUpdatedUtc { get; set; }
+}

--- a/Bot.Core/Services/ConversationStateOptions.cs
+++ b/Bot.Core/Services/ConversationStateOptions.cs
@@ -1,0 +1,7 @@
+namespace Bot.Core.Services;
+
+public class ConversationStateOptions
+{
+    public string RedisKeyPrefix { get; set; } = "session:";
+    public TimeSpan SessionTtl { get; set; } = TimeSpan.FromHours(24);
+}

--- a/Bot.Core/Services/ConversationStateService.cs
+++ b/Bot.Core/Services/ConversationStateService.cs
@@ -3,6 +3,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using StackExchange.Redis;
+using Bot.Core.Models;
 
 namespace Bot.Core.Services;
 
@@ -16,21 +17,6 @@ public interface IConversationStateService
     Task<string> GetStateAsync(Guid sessionId);
 }
 
-public class ConversationSession
-{
-    public Guid SessionId { get; set; }
-    public Guid UserId { get; set; }
-    public string PhoneNumber { get; set; } = null!;
-    public string State { get; set; } = "None";
-    public string? LastMessage { get; set; }
-    public DateTime LastUpdatedUtc { get; set; }
-}
-
-public class ConversationStateOptions
-{
-    public string RedisKeyPrefix { get; set; } = "session:";
-    public TimeSpan SessionTtl { get; set; } = TimeSpan.FromHours(24);
-}
 
 public class ConversationStateService(
     IConnectionMultiplexer redis,

--- a/Bot.Core/Services/DefaultSpeechRecognizerFactory.cs
+++ b/Bot.Core/Services/DefaultSpeechRecognizerFactory.cs
@@ -1,0 +1,13 @@
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+
+namespace Bot.Core.Services;
+
+public class DefaultSpeechRecognizerFactory : ISpeechRecognizerFactory
+{
+    public ISpeechRecognizer Create(SpeechConfig config, AutoDetectSourceLanguageConfig autoDetectConfig,
+        AudioConfig audioConfig)
+    {
+        return new SpeechRecognizerWrapper(new SpeechRecognizer(config, autoDetectConfig, audioConfig));
+    }
+}

--- a/Bot.Core/Services/ISpeechRecognizer.cs
+++ b/Bot.Core/Services/ISpeechRecognizer.cs
@@ -1,0 +1,6 @@
+namespace Bot.Core.Services;
+
+public interface ISpeechRecognizer : IAsyncDisposable
+{
+    Task<RecognitionResult> RecognizeOnceAsync();
+}

--- a/Bot.Core/Services/ISpeechRecognizerFactory.cs
+++ b/Bot.Core/Services/ISpeechRecognizerFactory.cs
@@ -1,0 +1,10 @@
+using Microsoft.CognitiveServices.Speech;
+using Microsoft.CognitiveServices.Speech.Audio;
+
+namespace Bot.Core.Services;
+
+public interface ISpeechRecognizerFactory
+{
+    ISpeechRecognizer Create(SpeechConfig config, AutoDetectSourceLanguageConfig autoDetectConfig,
+        AudioConfig audioConfig);
+}

--- a/Bot.Core/Services/ISpeechService.cs
+++ b/Bot.Core/Services/ISpeechService.cs
@@ -1,0 +1,6 @@
+namespace Bot.Core.Services;
+
+public interface ISpeechService
+{
+    Task<(string Text, string DetectedLanguage)> TranscribeAsync(Stream audioStream);
+}

--- a/Bot.Core/Services/ITranscriptionService.cs
+++ b/Bot.Core/Services/ITranscriptionService.cs
@@ -1,0 +1,6 @@
+namespace Bot.Core.Services;
+
+public interface ITranscriptionService
+{
+    Task<(string Text, string DetectedLanguage)> TranscribeAsync(Stream audioStream, string[] languageCodes);
+}

--- a/Bot.Core/Services/IWhatsAppService.cs
+++ b/Bot.Core/Services/IWhatsAppService.cs
@@ -1,0 +1,11 @@
+namespace Bot.Core.Services;
+
+public interface IWhatsAppService
+{
+    Task<string> SendTextMessageAsync(string toPhoneNumber, string message);
+    Task<string> SendMediaAsync(string toPhoneNumber, string mediaUrl, string caption = "");
+    Task<string> SendQuickReplyAsync(string toPhoneNumber, string header, string body, string[] buttonLabels);
+    Task<string> SendTemplateAsync(string toPhoneNumber, object template);
+    Task<string> SendVoiceAsync(string toPhoneNumber, Stream audio);
+    Task DeleteMessageAsync(string messageId);
+}

--- a/Bot.Core/Services/RecognitionResult.cs
+++ b/Bot.Core/Services/RecognitionResult.cs
@@ -1,0 +1,5 @@
+using Microsoft.CognitiveServices.Speech;
+
+namespace Bot.Core.Services;
+
+public record RecognitionResult(ResultReason Reason, string Text, string DetectedLanguage);

--- a/Bot.Core/Services/SpeechOptions.cs
+++ b/Bot.Core/Services/SpeechOptions.cs
@@ -1,0 +1,20 @@
+namespace Bot.Core.Services;
+
+/// <summary>
+///     Configuration for speech transcription: which languages to auto-detect.
+/// </summary>
+public class SpeechOptions
+{
+    /// <summary>
+    ///     A list of BCP-47 codes the TranscriptionService will try to auto-detect.
+    ///     E.g. "en-US","ig-NG","yo-NG","ha-NG","pcm-NG" (Nigerian Pidgin).
+    /// </summary>
+    public string[] SupportedLanguages { get; set; } = new[]
+    {
+        "en-US",
+        "ig-NG",
+        "yo-NG",
+        "ha-NG",
+        "pcm-NG"
+    };
+}

--- a/Bot.Core/Services/SpeechRecognizerWrapper.cs
+++ b/Bot.Core/Services/SpeechRecognizerWrapper.cs
@@ -1,0 +1,19 @@
+using Microsoft.CognitiveServices.Speech;
+
+namespace Bot.Core.Services;
+
+public class SpeechRecognizerWrapper(SpeechRecognizer recognizer) : ISpeechRecognizer
+{
+    public async Task<RecognitionResult> RecognizeOnceAsync()
+    {
+        var result = await recognizer.RecognizeOnceAsync();
+        var lang = result.Properties.GetProperty(PropertyId.SpeechServiceConnection_AutoDetectSourceLanguageResult);
+        return new RecognitionResult(result.Reason, result.Text, lang);
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        recognizer.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/Bot.Core/Services/SpeechService.cs
+++ b/Bot.Core/Services/SpeechService.cs
@@ -4,29 +4,6 @@ using Microsoft.Extensions.Options;
 
 namespace Bot.Core.Services;
 
-/// <summary>
-///     Configuration for speech transcription: which languages to auto-detect.
-/// </summary>
-public class SpeechOptions
-{
-    /// <summary>
-    ///     A list of BCP-47 codes the TranscriptionService will try to auto-detect.
-    ///     E.g. "en-US","ig-NG","yo-NG","ha-NG","pcm-NG" (Nigerian Pidgin).
-    /// </summary>
-    public string[] SupportedLanguages { get; set; } = new[]
-    {
-        "en-US",
-        "ig-NG",
-        "yo-NG",
-        "ha-NG",
-        "pcm-NG"
-    };
-}
-
-public interface ISpeechService
-{
-    Task<(string Text, string DetectedLanguage)> TranscribeAsync(Stream audioStream);
-}
 
 public class SpeechService(
     ITranscriptionService transcriber,

--- a/Bot.Core/Services/TranscriptionService.cs
+++ b/Bot.Core/Services/TranscriptionService.cs
@@ -1,50 +1,8 @@
 using Microsoft.CognitiveServices.Speech;
 using Microsoft.CognitiveServices.Speech.Audio;
 
+
 namespace Bot.Core.Services;
-
-public interface ITranscriptionService
-{
-    Task<(string Text, string DetectedLanguage)> TranscribeAsync(Stream audioStream, string[] languageCodes);
-}
-
-public record RecognitionResult(ResultReason Reason, string Text, string DetectedLanguage);
-
-public interface ISpeechRecognizer : IAsyncDisposable
-{
-    Task<RecognitionResult> RecognizeOnceAsync();
-}
-
-public interface ISpeechRecognizerFactory
-{
-    ISpeechRecognizer Create(SpeechConfig config, AutoDetectSourceLanguageConfig autoDetectConfig,
-        AudioConfig audioConfig);
-}
-
-public class SpeechRecognizerWrapper(SpeechRecognizer recognizer) : ISpeechRecognizer
-{
-    public async Task<RecognitionResult> RecognizeOnceAsync()
-    {
-        var result = await recognizer.RecognizeOnceAsync();
-        var lang = result.Properties.GetProperty(PropertyId.SpeechServiceConnection_AutoDetectSourceLanguageResult);
-        return new RecognitionResult(result.Reason, result.Text, lang);
-    }
-
-    public ValueTask DisposeAsync()
-    {
-        recognizer.Dispose();
-        return ValueTask.CompletedTask;
-    }
-}
-
-public class DefaultSpeechRecognizerFactory : ISpeechRecognizerFactory
-{
-    public ISpeechRecognizer Create(SpeechConfig config, AutoDetectSourceLanguageConfig autoDetectConfig,
-        AudioConfig audioConfig)
-    {
-        return new SpeechRecognizerWrapper(new SpeechRecognizer(config, autoDetectConfig, audioConfig));
-    }
-}
 
 public class TranscriptionService(string subscriptionKey, string region, ISpeechRecognizerFactory? factory = null)
     : ITranscriptionService

--- a/Bot.Core/Services/WhatsAppOptions.cs
+++ b/Bot.Core/Services/WhatsAppOptions.cs
@@ -1,0 +1,9 @@
+namespace Bot.Core.Services;
+
+public class WhatsAppOptions
+{
+    public string BaseUrl { get; set; } = "https://graph.facebook.com/v18.0";
+    public string PhoneNumberId { get; set; } = null!;
+    public string AccessToken { get; set; } = null!;
+    public TimeSpan EphemeralTtl { get; set; } = TimeSpan.FromMinutes(5);
+}

--- a/Bot.Core/Services/WhatsAppService.cs
+++ b/Bot.Core/Services/WhatsAppService.cs
@@ -5,25 +5,7 @@ using Microsoft.Extensions.Options;
 
 namespace Bot.Core.Services;
 
-public interface IWhatsAppService
-{
-    Task<string> SendTextMessageAsync(string toPhoneNumber, string message);
-    Task<string> SendMediaAsync(string toPhoneNumber, string mediaUrl, string caption = "");
-    Task<string> SendQuickReplyAsync(string toPhoneNumber, string header, string body, string[] buttonLabels);
-    Task<string> SendTemplateAsync(string toPhoneNumber, object template);
-    Task<string> SendVoiceAsync(string toPhoneNumber, Stream audio);
-    Task DeleteMessageAsync(string messageId);
-}
-
 // Bot.Infrastructure/Services/WhatsAppService.cs
-
-public class WhatsAppOptions
-{
-    public string BaseUrl { get; set; } = "https://graph.facebook.com/v18.0";
-    public string PhoneNumberId { get; set; } = null!;
-    public string AccessToken { get; set; } = null!;
-    public TimeSpan EphemeralTtl { get; set; } = TimeSpan.FromMinutes(5);
-}
 
 public class WhatsAppService : IWhatsAppService
 {

--- a/Bot.Tests/Consumers/ChatConsumersTests.cs
+++ b/Bot.Tests/Consumers/ChatConsumersTests.cs
@@ -1,4 +1,5 @@
 using Bot.Core.Services;
+using Bot.Core.Models;
 using Bot.Core.StateMachine.Consumers.Chat;
 using Bot.Infrastructure.Data;
 using Bot.Shared;

--- a/Bot.Tests/Consumers/PromptCmdConsumerTests.cs
+++ b/Bot.Tests/Consumers/PromptCmdConsumerTests.cs
@@ -1,4 +1,5 @@
 using Bot.Core.Services;
+using Bot.Core.Models;
 using Bot.Core.StateMachine.Consumers.UX;
 using Bot.Shared.DTOs;
 using MassTransit;

--- a/Bot.Tests/Services/ConversationStateServiceTests.cs
+++ b/Bot.Tests/Services/ConversationStateServiceTests.cs
@@ -1,4 +1,5 @@
 using Bot.Core.Services;
+using Bot.Core.Models;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;

--- a/Bot.Tests/TestUtilities/FakeConversationStateService.cs
+++ b/Bot.Tests/TestUtilities/FakeConversationStateService.cs
@@ -1,4 +1,5 @@
 using Bot.Core.Services;
+using Bot.Core.Models;
 
 namespace Bot.Tests.TestUtilities;
 


### PR DESCRIPTION
## Summary
- extract ConversationSession/ConversationStateOptions to their own files
- split SpeechService related types
- split TranscriptionService helper types
- split WhatsApp service contracts
- update tests for new namespaces

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*
- `dotnet test --no-build` *(fails: dotnet not found)*