### PR TITLE
Move NudgeType enum

### DIFF
--- a/Bot.Core/Services/NudgeService.cs
+++ b/Bot.Core/Services/NudgeService.cs
@@ -1,5 +1,5 @@
 using Bot.Infrastructure.Data;
-using Bot.Shared;
+using Bot.Shared.Enums;
 using Bot.Shared.Models;
 
 namespace Bot.Core.Services;

--- a/Bot.Shared/Enums/NudgeType.cs
+++ b/Bot.Shared/Enums/NudgeType.cs
@@ -1,0 +1,27 @@
+namespace Bot.Shared.Enums;
+
+public enum NudgeType
+{
+    BadPin,
+    TransferFail,
+    BudgetAlert,
+    RecurringCancelled,
+    InvalidBvn,
+    ServiceDown,
+    InvalidNin,
+    WaitingOnMandate,
+    Greeting,
+    Unknown,
+    SignupRequired,
+    AlreadyOnboarded,
+    TimedOut,
+    FloodProtection,
+    Canceled,
+    Help,
+    SignupFailed,
+    BankFailed,
+    KycFailed,
+    BillFailed,
+    RecurringFailed
+}
+

--- a/Bot.Shared/Payloads.cs
+++ b/Bot.Shared/Payloads.cs
@@ -34,29 +34,3 @@ public record SignupPayload(string FullName, string Phone, string NIN, string BV
 public record GreetingPayload(string Message);
 
 public record UnknownPayload(string Message);
-
-// UX
-public enum NudgeType
-{
-    BadPin,
-    TransferFail,
-    BudgetAlert,
-    RecurringCancelled,
-    InvalidBvn,
-    ServiceDown,
-    InvalidNin,
-    WaitingOnMandate,
-    Greeting,
-    Unknown,
-    SignupRequired,
-    AlreadyOnboarded,
-    TimedOut,
-    FloodProtection,
-    Canceled,
-    Help,
-    SignupFailed,
-    BankFailed,
-    KycFailed,
-    BillFailed,
-    RecurringFailed
-}

--- a/Bot.Tests/Consumers/UxConsumersTests.cs
+++ b/Bot.Tests/Consumers/UxConsumersTests.cs
@@ -5,6 +5,7 @@ using Bot.Infrastructure.Data;
 using Bot.Shared;
 using Bot.Shared.DTOs;
 using Bot.Shared.Models;
+using Bot.Shared.Enums;
 using Bot.Tests.TestUtilities;
 using FluentAssertions;
 using MassTransit.Testing;

--- a/Bot.Tests/Services/NudgeServiceTests.cs
+++ b/Bot.Tests/Services/NudgeServiceTests.cs
@@ -2,6 +2,7 @@ using Bot.Core.Services;
 using Bot.Infrastructure.Data;
 using Bot.Shared;
 using Bot.Shared.Models;
+using Bot.Shared.Enums;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 


### PR DESCRIPTION
## Summary
- create shared enum `NudgeType`
- remove old enum from `Payloads`
- update service and tests to use the new namespace

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*